### PR TITLE
fix: specify common version

### DIFF
--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -14,7 +14,7 @@ anyhow.workspace = true
 cfg-if.workspace = true
 
 # local
-kona-common = { path = "../common" }
+kona-common = { path = "../common", version = "0.0.1" }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["full"] }


### PR DESCRIPTION
## Overview

Specifies the version of `kona-common` to use in `kona-preimage` for `release-plz`.