### PR TITLE
fix: Data Sources Async Iterator

### DIFF
--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -157,9 +157,9 @@ where
     F: ChainProvider + Send,
     B: BlobProvider + Send,
 {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
 
-    async fn next(&mut self) -> Option<Self::Item> {
+    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
         if self.load_blobs().await.is_err() {
             return Some(Err(StageError::BlockFetch(self.block_ref.hash)));
         }

--- a/crates/derive/src/sources/calldata.rs
+++ b/crates/derive/src/sources/calldata.rs
@@ -79,9 +79,9 @@ impl<CP: ChainProvider + Send> CalldataSource<CP> {
 
 #[async_trait]
 impl<CP: ChainProvider + Send> AsyncIterator for CalldataSource<CP> {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
 
-    async fn next(&mut self) -> Option<Self::Item> {
+    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
         if self.load_calldata().await.is_err() {
             return Some(Err(StageError::BlockFetch(self.block_ref.hash)));
         }

--- a/crates/derive/src/sources/factory.rs
+++ b/crates/derive/src/sources/factory.rs
@@ -2,10 +2,11 @@
 
 use crate::sources::{BlobSource, CalldataSource, DataSource, PlasmaSource};
 use crate::traits::{BlobProvider, ChainProvider, DataAvailabilityProvider};
-use crate::types::{BlockInfo, RollupConfig, StageResult};
+use crate::types::{BlockInfo, RollupConfig};
 use alloc::boxed::Box;
 use alloc::fmt::Debug;
 use alloy_primitives::Address;
+use alloy_primitives::Bytes;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
@@ -51,7 +52,7 @@ where
     C: ChainProvider + Send + Sync + Clone + Debug,
     B: BlobProvider + Send + Sync + Clone + Debug,
 {
-    type Item = StageResult<alloy_primitives::Bytes>;
+    type Item = Bytes;
     type DataIter = DataSource<C, B>;
 
     async fn open_data(

--- a/crates/derive/src/sources/factory.rs
+++ b/crates/derive/src/sources/factory.rs
@@ -2,7 +2,7 @@
 
 use crate::sources::{BlobSource, CalldataSource, DataSource, PlasmaSource};
 use crate::traits::{BlobProvider, ChainProvider, DataAvailabilityProvider};
-use crate::types::{BlockInfo, RollupConfig};
+use crate::types::{BlockInfo, RollupConfig, StageResult};
 use alloc::boxed::Box;
 use alloc::fmt::Debug;
 use alloy_primitives::Address;
@@ -51,6 +51,7 @@ where
     C: ChainProvider + Send + Sync + Clone + Debug,
     B: BlobProvider + Send + Sync + Clone + Debug,
 {
+    type Item = StageResult<alloy_primitives::Bytes>;
     type DataIter = DataSource<C, B>;
 
     async fn open_data(

--- a/crates/derive/src/sources/plasma.rs
+++ b/crates/derive/src/sources/plasma.rs
@@ -37,9 +37,9 @@ impl<CP: ChainProvider + Send> PlasmaSource<CP> {
 
 #[async_trait]
 impl<CP: ChainProvider + Send> AsyncIterator for PlasmaSource<CP> {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
 
-    async fn next(&mut self) -> Option<Self::Item> {
+    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
         unimplemented!("Plasma will not be supported until further notice.");
     }
 }

--- a/crates/derive/src/sources/source.rs
+++ b/crates/derive/src/sources/source.rs
@@ -28,9 +28,9 @@ where
     CP: ChainProvider + Send,
     B: BlobProvider + Send,
 {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
 
-    async fn next(&mut self) -> Option<Self::Item> {
+    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
         match self {
             DataSource::Calldata(c) => c.next().await,
             DataSource::Blob(b) => b.next().await,

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -4,8 +4,8 @@ use core::fmt::Debug;
 
 use super::l1_retrieval::L1Retrieval;
 use crate::{
-    traits::{ChainProvider, DataAvailabilityProvider, IntoFrames, ResettableStage},
-    types::{BlockInfo, Frame, StageError, StageResult, SystemConfig},
+    traits::{ChainProvider, DataAvailabilityProvider, ResettableStage},
+    types::{into_frames, BlockInfo, Frame, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, collections::VecDeque};
 use anyhow::anyhow;
@@ -47,8 +47,7 @@ where
         if self.queue.is_empty() {
             match self.prev.next_data().await {
                 Ok(data) => {
-                    // TODO: what do we do with frame parsing errors?
-                    if let Ok(frames) = data.into_frames() {
+                    if let Ok(frames) = into_frames(Ok(data)) {
                         self.queue.extend(frames);
                     }
                 }

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 
 use super::l1_retrieval::L1Retrieval;
 use crate::{
-    traits::{ChainProvider, DataAvailabilityProvider, ResettableStage},
+    traits::{ChainProvider, DataAvailabilityProvider, IntoFrames, ResettableStage},
     types::{BlockInfo, Frame, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, collections::VecDeque};
@@ -48,7 +48,7 @@ where
             match self.prev.next_data().await {
                 Ok(data) => {
                     // TODO: what do we do with frame parsing errors?
-                    if let Ok(frames) = Frame::parse_frames(data.as_ref()) {
+                    if let Ok(frames) = data.into_frames() {
                         self.queue.extend(frames);
                     }
                 }

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -67,12 +67,12 @@ where
             .await
             .ok_or(StageError::Eof);
         match data {
-            Ok(data) => Ok(data),
-            Err(StageError::Eof) => {
+            Ok(Ok(data)) => Ok(data),
+            Err(StageError::Eof) | Ok(Err(StageError::Eof)) => {
                 self.data = None;
                 Err(StageError::Eof)
             }
-            Err(e) => Err(e),
+            Ok(Err(e)) | Err(e) => Err(e),
         }
     }
 }
@@ -114,7 +114,7 @@ mod tests {
         let dap = TestDAP { results };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         assert_eq!(retrieval.data, None);
-        let data = retrieval.next_data().await.unwrap().unwrap();
+        let data = retrieval.next_data().await.unwrap();
         assert_eq!(data, Bytes::default());
         assert!(retrieval.data.is_some());
         let retrieval_data = retrieval.data.as_ref().unwrap();
@@ -143,7 +143,7 @@ mod tests {
             provider: dap,
             data: Some(data),
         };
-        let data = retrieval.next_data().await.unwrap().unwrap();
+        let data = retrieval.next_data().await.unwrap();
         assert_eq!(data, Bytes::default());
         assert!(retrieval.data.is_some());
         let retrieval_data = retrieval.data.as_ref().unwrap();

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -1,6 +1,6 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation pipeline's stages.
 
-use crate::types::{Blob, BlockInfo, Frame, IndexedBlobHash, Receipt, TxEnvelope};
+use crate::types::{Blob, BlockInfo, IndexedBlobHash, Receipt, StageResult, TxEnvelope};
 use alloc::fmt::Debug;
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, B256};
@@ -44,28 +44,22 @@ pub trait ChainProvider {
     ) -> Result<(BlockInfo, Vec<TxEnvelope>)>;
 }
 
-/// Allows a type to be converted into a list of frames.
-pub trait IntoFrames {
-    /// Converts the type into a list of frames.
-    fn into_frames(self) -> Result<Vec<Frame>>;
-}
-
 /// A simple asynchronous iterator trait.
 /// This should be replaced with the `async-iterator` crate
 #[async_trait]
 pub trait AsyncIterator {
     /// The item type of the iterator.
-    type Item: Send + Sync + Debug + IntoFrames;
+    type Item: Send + Sync + Debug + Into<Bytes>;
 
     /// Returns the next item in the iterator, or [crate::types::StageError::Eof] if the iterator is exhausted.
-    async fn next(&mut self) -> Option<Self::Item>;
+    async fn next(&mut self) -> Option<StageResult<Self::Item>>;
 }
 
 /// Describes the functionality of a data source that can provide data availability information.
 #[async_trait]
 pub trait DataAvailabilityProvider {
     /// The item type of the data iterator.
-    type Item: Send + Sync + Debug + IntoFrames;
+    type Item: Send + Sync + Debug + Into<Bytes>;
     /// An iterator over returned bytes data.
     type DataIter: AsyncIterator<Item = Self::Item> + Send + Debug;
 

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -1,7 +1,9 @@
 //! This module contains all of the traits describing functionality of portions of the derivation pipeline.
 
 mod data_sources;
-pub use data_sources::{AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider};
+pub use data_sources::{
+    AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider, IntoFrames,
+};
 
 mod stages;
 pub use stages::ResettableStage;

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -1,9 +1,7 @@
 //! This module contains all of the traits describing functionality of portions of the derivation pipeline.
 
 mod data_sources;
-pub use data_sources::{
-    AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider, IntoFrames,
-};
+pub use data_sources::{AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider};
 
 mod stages;
 pub use stages::ResettableStage;

--- a/crates/derive/src/traits/test_utils/data_availability.rs
+++ b/crates/derive/src/traits/test_utils/data_availability.rs
@@ -21,9 +21,9 @@ pub struct TestIter {
 
 #[async_trait]
 impl AsyncIterator for TestIter {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
 
-    async fn next(&mut self) -> Option<Self::Item> {
+    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
         Some(self.results.pop().unwrap_or_else(|| Err(StageError::Eof)))
     }
 }
@@ -37,7 +37,7 @@ pub struct TestDAP {
 
 #[async_trait]
 impl DataAvailabilityProvider for TestDAP {
-    type Item = StageResult<Bytes>;
+    type Item = Bytes;
     type DataIter = TestIter;
 
     async fn open_data(

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -1,7 +1,7 @@
 //! Data Sources Test Utilities
 
 use crate::traits::ChainProvider;
-use crate::types::{BlockInfo, Receipt};
+use crate::types::{BlockInfo, Receipt, TxEnvelope};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::B256;
 use anyhow::Result;
@@ -60,5 +60,18 @@ impl ChainProvider for TestChainProvider {
         } else {
             Err(anyhow::anyhow!("Receipts not found"))
         }
+    }
+
+    async fn block_info_and_transactions_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
+        let block = self
+            .blocks
+            .iter()
+            .find(|(_, b)| b.hash == hash)
+            .map(|(_, b)| *b)
+            .ok_or_else(|| anyhow::anyhow!("Block not found"))?;
+        Ok((block, Vec::new()))
     }
 }

--- a/crates/derive/src/types/errors.rs
+++ b/crates/derive/src/types/errors.rs
@@ -1,9 +1,8 @@
 //! This module contains derivation errors thrown within the pipeline.
 
 use super::Frame;
-use crate::traits::IntoFrames;
 use alloc::vec::Vec;
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use core::fmt::Display;
 
 /// An error that is thrown within the stages of the derivation pipeline.
@@ -36,12 +35,11 @@ impl PartialEq<StageError> for StageError {
 /// A result type for the derivation pipeline stages.
 pub type StageResult<T> = Result<T, StageError>;
 
-impl<T: Into<alloy_primitives::Bytes>> IntoFrames for StageResult<T> {
-    fn into_frames(self) -> anyhow::Result<Vec<Frame>> {
-        match self {
-            Ok(data) => Ok(Frame::parse_frames(&data.into())?),
-            Err(e) => Err(anyhow::anyhow!(e)),
-        }
+/// Converts a stage result into a vector of frames.
+pub fn into_frames<T: Into<Bytes>>(result: StageResult<T>) -> anyhow::Result<Vec<Frame>> {
+    match result {
+        Ok(data) => Ok(Frame::parse_frames(&data.into())?),
+        Err(e) => Err(anyhow::anyhow!(e)),
     }
 }
 

--- a/crates/derive/src/types/errors.rs
+++ b/crates/derive/src/types/errors.rs
@@ -1,5 +1,8 @@
 //! This module contains derivation errors thrown within the pipeline.
 
+use super::Frame;
+use crate::traits::IntoFrames;
+use alloc::vec::Vec;
 use alloy_primitives::B256;
 use core::fmt::Display;
 
@@ -32,6 +35,15 @@ impl PartialEq<StageError> for StageError {
 
 /// A result type for the derivation pipeline stages.
 pub type StageResult<T> = Result<T, StageError>;
+
+impl<T: Into<alloy_primitives::Bytes>> IntoFrames for StageResult<T> {
+    fn into_frames(self) -> anyhow::Result<Vec<Frame>> {
+        match self {
+            Ok(data) => Ok(Frame::parse_frames(&data.into())?),
+            Err(e) => Err(anyhow::anyhow!(e)),
+        }
+    }
+}
 
 impl From<anyhow::Error> for StageError {
     fn from(e: anyhow::Error) -> Self {

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -46,7 +46,7 @@ mod channel;
 pub use channel::Channel;
 
 mod errors;
-pub use errors::{StageError, StageResult};
+pub use errors::{into_frames, StageError, StageResult};
 
 mod single_batch;
 pub use single_batch::SingleBatch;


### PR DESCRIPTION
**Description**

Fixes up the async iterator usage.

Nested associated types were not behaving nicely, so I duped the `Item` type and piped it into the iterator.

This has the unfortunate trait that the item has to be bounded to a new `IntoFrames` trait that allows the frame queue to transform the item into frames... There must be a better way to architect this, but I'll stash this for now.