### PR TITLE
fix(derive): Share the RollupConfig across Stages with an Arc

### DIFF
--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -6,6 +6,7 @@ use crate::{
     traits::{ChainProvider, DataAvailabilityProvider, ResettableStage},
     types::{BlockInfo, Channel, Frame, RollupConfig, StageError, StageResult, SystemConfig},
 };
+use alloc::sync::Arc;
 use alloc::{boxed::Box, collections::VecDeque};
 use alloy_primitives::Bytes;
 use anyhow::anyhow;
@@ -31,7 +32,7 @@ where
     CP: ChainProvider + Debug,
 {
     /// The rollup configuration.
-    cfg: RollupConfig,
+    cfg: Arc<RollupConfig>,
     /// Map of channels by ID.
     channels: HashMap<ChannelID, Channel>,
     /// Channels in FIFO order.
@@ -48,7 +49,7 @@ where
     /// Create a new [ChannelBank] stage.
     pub fn new(cfg: RollupConfig, prev: FrameQueue<DAP, CP>) -> Self {
         Self {
-            cfg,
+            cfg: Arc::new(cfg),
             channels: HashMap::new(),
             channel_queue: VecDeque::new(),
             prev,

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -5,11 +5,12 @@ use crate::{
     types::{BlockInfo, RollupConfig, StageError, StageResult, SystemConfig},
 };
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 
 /// The L1 traversal stage of the derivation pipeline.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct L1Traversal<Provider: ChainProvider> {
     /// The current block in the traversal stage.
     pub(crate) block: Option<BlockInfo>,
@@ -20,7 +21,7 @@ pub struct L1Traversal<Provider: ChainProvider> {
     /// The system config
     pub system_config: SystemConfig,
     /// The rollup config
-    pub rollup_config: RollupConfig,
+    pub rollup_config: Arc<RollupConfig>,
 }
 
 impl<F: ChainProvider> L1Traversal<F> {
@@ -31,7 +32,7 @@ impl<F: ChainProvider> L1Traversal<F> {
             data_source,
             done: false,
             system_config: SystemConfig::default(),
-            rollup_config: cfg,
+            rollup_config: Arc::new(cfg),
         }
     }
 


### PR DESCRIPTION
**Description**

Performs the naive implementation to share the `RollupConfig` across stages by wrapping it in an `Arc`.

**Metadata**

Fixes #70 