### PR TITLE
feat(ci): Add workflow to cycle issues

### DIFF
--- a/.github/workflows/issue_cycler.yaml
+++ b/.github/workflows/issue_cycler.yaml
@@ -1,0 +1,20 @@
+on:
+  schedule:
+    # Runs "at 05:00, only on Monday" (see https://crontab.guru)
+    - cron: "0 5 * * 1"
+
+jobs:
+  move-to-next-iteration:
+    name: Move to next iteration
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: blombard/move-to-next-iteration@master
+        with:
+          owner: ethereum-optimism
+          number: 60
+          token: ${{ secrets.GITHUB_TOKEN }}
+          iteration-field: Cycle
+          iteration: last
+          new-iteration: current
+          excluded-statuses: "Done"


### PR DESCRIPTION
## Overview

Adds a workflow that runs every Monday morning at `05:00` that moves any issues placed in the previous cycle, that aren't `Done`, to the current cycle in the `kona-development` project.