### PR TITLE
fix(derive): Frame Queue Error Bubbling and Docs

### DIFF
--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -255,6 +255,6 @@ mod tests {
         let err = channel_bank.read().unwrap_err();
         assert_eq!(err, StageError::Eof);
         let err = channel_bank.next_data().await.unwrap_err();
-        assert_eq!(err, StageError::Custom(anyhow!("Not Enough Data")));
+        assert_eq!(err, StageError::NotEnoughData);
     }
 }

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 
 /// The [FrameQueue] stage of the derivation pipeline.
-///
+/// This stage takes the output of the [L1Retrieval] stage and parses it into frames.
 #[derive(Debug)]
 pub struct FrameQueue<DAP, CP>
 where


### PR DESCRIPTION
**Description**

Fixes up frame queue bubbling. Previously, errors were being wrapped where they shouldn't have been.

Also cleans up frame queue docs and notes where logging should be introduced.