### PR TITLE
fix(derive): OriginProvider Trait Usage

### DIFF
--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -73,11 +73,6 @@ where
         Self { cfg, prev, telemetry, is_last_in_span: false, batch: None, builder }
     }
 
-    /// Returns the L1 origin [BlockInfo].
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
-    }
-
     /// Loads a [SingleBatch] from the [AttributesProvider] if needed.
     pub async fn load_batch(&mut self, parent: L2BlockInfo) -> StageResult<SingleBatch> {
         if self.batch.is_none() {
@@ -147,6 +142,17 @@ where
         );
 
         Ok(attributes)
+    }
+}
+
+impl<P, T, AB> OriginProvider for AttributesQueue<P, T, AB>
+where
+    P: AttributesProvider + OriginProvider + Debug,
+    T: TelemetryProvider + Debug,
+    AB: AttributesBuilder + Debug,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -3,7 +3,7 @@
 use crate::{
     stages::channel_reader::ChannelReader,
     traits::{
-        ChainProvider, DataAvailabilityProvider, ResettableStage, SafeBlockFetcher,
+        ChainProvider, DataAvailabilityProvider, OriginProvider, ResettableStage, SafeBlockFetcher,
         TelemetryProvider,
     },
     types::{
@@ -81,11 +81,6 @@ where
             next_spans: Vec::new(),
             fetcher,
         }
-    }
-
-    /// Returns the L1 origin [BlockInfo].
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
     }
 
     /// Returns if the previous batch was the last in the span.
@@ -350,6 +345,18 @@ where
         }
         self.batches.push(data);
         Ok(())
+    }
+}
+
+impl<DAP, CP, BF, T> OriginProvider for BatchQueue<DAP, CP, BF, T>
+where
+    DAP: DataAvailabilityProvider + Debug,
+    CP: ChainProvider + Debug,
+    BF: SafeBlockFetcher + Debug,
+    T: TelemetryProvider + Debug,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -4,7 +4,8 @@ use super::frame_queue::FrameQueue;
 use crate::{
     params::{ChannelID, MAX_CHANNEL_BANK_SIZE},
     traits::{
-        ChainProvider, DataAvailabilityProvider, LogLevel, ResettableStage, TelemetryProvider,
+        ChainProvider, DataAvailabilityProvider, LogLevel, OriginProvider, ResettableStage,
+        TelemetryProvider,
     },
     types::{BlockInfo, Channel, Frame, RollupConfig, StageError, StageResult, SystemConfig},
 };
@@ -54,11 +55,6 @@ where
     /// Create a new [ChannelBank] stage.
     pub fn new(cfg: Arc<RollupConfig>, prev: FrameQueue<DAP, CP, T>, telemetry: T) -> Self {
         Self { cfg, telemetry, channels: HashMap::new(), channel_queue: VecDeque::new(), prev }
-    }
-
-    /// Returns the L1 origin [BlockInfo].
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
     }
 
     /// Returns the size of the channel bank by accumulating over all channels.
@@ -199,6 +195,17 @@ where
         self.channel_queue.remove(index);
 
         frame_data.map_err(StageError::Custom)
+    }
+}
+
+impl<DAP, CP, T> OriginProvider for ChannelBank<DAP, CP, T>
+where
+    DAP: DataAvailabilityProvider + Debug,
+    CP: ChainProvider + Debug,
+    T: TelemetryProvider + Debug,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -2,7 +2,9 @@
 
 use super::channel_bank::ChannelBank;
 use crate::{
-    traits::{ChainProvider, DataAvailabilityProvider, LogLevel, TelemetryProvider},
+    traits::{
+        ChainProvider, DataAvailabilityProvider, LogLevel, OriginProvider, TelemetryProvider,
+    },
     types::{Batch, BlockInfo, StageError, StageResult},
 };
 
@@ -70,15 +72,21 @@ where
         Ok(())
     }
 
-    /// Returns the L1 origin [BlockInfo].
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
-    }
-
     /// Forces the read to continue with the next channel, resetting any
     /// decoding / decompression state to a fresh start.
     pub fn next_channel(&mut self) {
         self.next_batch = None;
+    }
+}
+
+impl<DAP, CP, T> OriginProvider for ChannelReader<DAP, CP, T>
+where
+    DAP: DataAvailabilityProvider + Debug,
+    CP: ChainProvider + Debug,
+    T: TelemetryProvider + Debug,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -5,7 +5,8 @@ use core::fmt::Debug;
 use super::l1_retrieval::L1Retrieval;
 use crate::{
     traits::{
-        ChainProvider, DataAvailabilityProvider, LogLevel, ResettableStage, TelemetryProvider,
+        ChainProvider, DataAvailabilityProvider, LogLevel, OriginProvider, ResettableStage,
+        TelemetryProvider,
     },
     types::{BlockInfo, Frame, StageError, StageResult, SystemConfig},
 };
@@ -41,11 +42,6 @@ where
         Self { prev, telemetry, queue: VecDeque::new() }
     }
 
-    /// Returns the L1 [BlockInfo] origin.
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
-    }
-
     /// Fetches the next frame from the [FrameQueue].
     pub async fn next_frame(&mut self) -> StageResult<Frame> {
         if self.queue.is_empty() {
@@ -78,6 +74,17 @@ where
         }
 
         self.queue.pop_front().ok_or_else(|| anyhow!("Frame queue is impossibly empty.").into())
+    }
+}
+
+impl<DAP, CP, T> OriginProvider for FrameQueue<DAP, CP, T>
+where
+    DAP: DataAvailabilityProvider + Debug,
+    CP: ChainProvider + Debug,
+    T: TelemetryProvider + Debug,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -3,8 +3,8 @@
 use super::L1Traversal;
 use crate::{
     traits::{
-        ChainProvider, DataAvailabilityProvider, DataIter, LogLevel, ResettableStage,
-        TelemetryProvider,
+        ChainProvider, DataAvailabilityProvider, DataIter, LogLevel, OriginProvider,
+        ResettableStage, TelemetryProvider,
     },
     types::{BlockInfo, StageError, StageResult, SystemConfig},
 };
@@ -47,12 +47,6 @@ where
         Self { prev, telemetry, provider, data: None }
     }
 
-    /// Returns the current L1 [BlockInfo] origin from the previous
-    /// [L1Traversal] stage.
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.prev.origin()
-    }
-
     /// Retrieves the next data item from the [L1Retrieval] stage.
     /// Returns an error if there is no data.
     pub async fn next_data(&mut self) -> StageResult<Bytes> {
@@ -78,6 +72,17 @@ where
             }
             Err(e) => Err(e),
         }
+    }
+}
+
+impl<DAP, CP, T> OriginProvider for L1Retrieval<DAP, CP, T>
+where
+    DAP: DataAvailabilityProvider,
+    CP: ChainProvider,
+    T: TelemetryProvider,
+{
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.prev.origin()
     }
 }
 

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -1,7 +1,7 @@
 //! Contains the [L1Traversal] stage of the derivation pipeline.
 
 use crate::{
-    traits::{ChainProvider, LogLevel, ResettableStage, TelemetryProvider},
+    traits::{ChainProvider, LogLevel, OriginProvider, ResettableStage, TelemetryProvider},
     types::{BlockInfo, RollupConfig, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, sync::Arc};
@@ -61,11 +61,6 @@ impl<F: ChainProvider, T: TelemetryProvider> L1Traversal<F, T> {
         }
     }
 
-    /// Returns the current L1 [BlockInfo] in the [L1Traversal] stage, if it exists.
-    pub fn origin(&self) -> Option<&BlockInfo> {
-        self.block.as_ref()
-    }
-
     /// Advances the internal state of the [L1Traversal] stage to the next L1 block.
     /// This function fetches the next L1 [BlockInfo] from the data source and updates the
     /// [SystemConfig] with the receipts from the block.
@@ -109,6 +104,12 @@ impl<F: ChainProvider, T: TelemetryProvider> L1Traversal<F, T> {
         self.block = Some(next_l1_origin);
         self.done = false;
         Ok(())
+    }
+}
+
+impl<F: ChainProvider, T: TelemetryProvider> OriginProvider for L1Traversal<F, T> {
+    fn origin(&self) -> Option<&BlockInfo> {
+        self.block.as_ref()
     }
 }
 


### PR DESCRIPTION
**Description**

Implements the `OriginProvider` across stages, removing the method definitions.