### PR TITLE
feat(derive): Online `ChainProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1465,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1490,26 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1501,10 +1548,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2213,6 +2330,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2357,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -2415,6 +2561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,6 +2675,82 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "hashbrown",
+ "lru",
  "miniz_oxide",
  "proptest",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,13 +2277,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "serde",
  "sha2",
 ]
 
@@ -54,6 +57,46 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "c-kzg",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "async-trait",
+ "futures-utils-wasm",
+ "thiserror",
 ]
 
 [[package]]
@@ -70,9 +113,38 @@ dependencies = [
  "hex-literal",
  "itoa",
  "k256",
+ "keccak-asm",
+ "proptest",
+ "rand",
  "ruint",
  "serde",
  "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-rpc-types-trace",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "lru",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -82,6 +154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "alloy-rlp-derive",
+ "arrayvec",
  "bytes",
 ]
 
@@ -97,6 +170,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-client"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-serde"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
@@ -104,6 +227,19 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
 ]
 
 [[package]]
@@ -151,16 +287,210 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.0",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower",
+ "url",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -195,6 +525,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +570,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,11 +591,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3130f3d8717cc02e668a896af24984d5d5d4e8bf12e278e982e0f1bd88a0f9af"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
  "serde",
 ]
 
@@ -277,6 +681,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +754,17 @@ checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -332,8 +776,17 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -361,11 +814,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -375,10 +835,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -408,6 +869,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,10 +890,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
@@ -450,6 +1059,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -511,7 +1126,132 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -525,10 +1265,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "k256"
@@ -539,7 +1312,18 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -558,13 +1342,16 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-rlp",
  "alloy-sol-types",
+ "alloy-transport-http",
  "anyhow",
  "async-trait",
  "hashbrown",
  "miniz_oxide",
  "proptest",
+ "reqwest",
  "serde",
  "spin",
  "tokio",
@@ -640,6 +1427,12 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -742,16 +1535,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -822,6 +1695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1755,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,14 +1804,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "ruint"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
  "proptest",
  "rand",
+ "rlp",
  "ruint-macro",
  "serde",
  "valuable",
@@ -913,12 +1850,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.22",
 ]
 
 [[package]]
@@ -933,6 +1885,22 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rusty-fork"
@@ -953,6 +1921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,8 +1944,41 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
 ]
 
 [[package]]
@@ -976,6 +1986,15 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1009,6 +2028,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,7 +2047,17 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1043,8 +2084,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1080,6 +2130,22 @@ checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1122,6 +2188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +2229,21 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1234,10 +2327,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -1246,16 +2363,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1270,6 +2413,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1433,6 +2585,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,3 +2637,17 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -39,7 +39,7 @@ spin = { version = "0.9.8", features = ["mutex"] } # Spin is used for testing sy
 tracing-subscriber = "0.3.18"
 
 [features]
-default = ["serde", "k256"]
+default = ["serde", "k256", "alloy-providers"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
 alloy-providers = [

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1.77"
 hashbrown = "0.14.3"
 unsigned-varint = "0.8.0"
 miniz_oxide = { version = "0.7.2" }
+lru = "0.12.3"
 
 # `serde` feature dependencies
 serde = { version = "1.0.197", default-features = false, features = ["derive"], optional = true }
@@ -39,7 +40,7 @@ spin = { version = "0.9.8", features = ["mutex"] } # Spin is used for testing sy
 tracing-subscriber = "0.3.18"
 
 [features]
-default = ["serde", "k256", "alloy-providers"]
+default = ["serde", "k256"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
 alloy-providers = [

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -28,7 +28,7 @@ lru = "0.12.3"
 # `serde` feature dependencies
 serde = { version = "1.0.197", default-features = false, features = ["derive"], optional = true }
 
-# `alloy-providers` feature dependencies
+# `online` feature dependencies
 alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", optional = true} 
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", optional = true } 
 reqwest = { version = "0.12", default-features = false, optional = true }
@@ -43,7 +43,7 @@ tracing-subscriber = "0.3.18"
 default = ["serde", "k256"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
-alloy-providers = [
+online = [
   "dep:alloy-provider",
   "dep:alloy-transport-http",
   "dep:reqwest",

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -24,8 +24,13 @@ hashbrown = "0.14.3"
 unsigned-varint = "0.8.0"
 miniz_oxide = { version = "0.7.2" }
 
-# Optional
+# `serde` feature dependencies
 serde = { version = "1.0.197", default-features = false, features = ["derive"], optional = true }
+
+# `alloy-providers` feature dependencies
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", optional = true} 
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", optional = true } 
+reqwest = { version = "0.12", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.36", features = ["full"] }
@@ -37,3 +42,9 @@ tracing-subscriber = "0.3.18"
 default = ["serde", "k256"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
+alloy-providers = [
+  "dep:alloy-provider",
+  "dep:alloy-transport-http",
+  "dep:reqwest",
+  "alloy-consensus/serde"
+]

--- a/crates/derive/src/alloy_providers.rs
+++ b/crates/derive/src/alloy_providers.rs
@@ -2,7 +2,7 @@
 //! provider on the backend.
 
 use crate::{
-    traits::{ChainProvider, L2SafeBlockFetcher},
+    traits::{ChainProvider, L2ChainProvider},
     types::{Block, BlockInfo, ExecutionPayloadEnvelope, L2BlockInfo, RollupConfig},
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
@@ -132,7 +132,7 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
     }
 }
 
-/// The [AlloyL2SafeHeadProvider] is a concrete implementation of the [L2SafeBlockFetcher] trait,
+/// The [AlloyL2SafeHeadProvider] is a concrete implementation of the [L2ChainProvider] trait,
 /// providing data over Ethereum JSON-RPC using an alloy provider as the backend.
 ///
 /// **Note**:
@@ -163,7 +163,7 @@ impl<T: Provider<Http<reqwest::Client>>> AlloyL2SafeHeadProvider<T> {
 }
 
 #[async_trait]
-impl<T: Provider<Http<reqwest::Client>>> L2SafeBlockFetcher for AlloyL2SafeHeadProvider<T> {
+impl<T: Provider<Http<reqwest::Client>>> L2ChainProvider for AlloyL2SafeHeadProvider<T> {
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
         if let Some(l2_block_info) = self.l2_block_info_by_number_cache.get(&number) {
             return Ok(*l2_block_info);

--- a/crates/derive/src/alloy_providers.rs
+++ b/crates/derive/src/alloy_providers.rs
@@ -1,0 +1,102 @@
+//! This module contains concrete implementations of the data provider traits, using an alloy
+//! provider on the backend.
+
+use crate::{
+    traits::ChainProvider,
+    types::{Block, BlockInfo},
+};
+use alloc::{boxed::Box, vec::Vec};
+use alloy_consensus::{Header, Receipt, ReceiptWithBloom, TxEnvelope, TxType};
+use alloy_primitives::{Bytes, B256, U64};
+use alloy_provider::Provider;
+use alloy_rlp::{Buf, Decodable};
+use alloy_transport_http::Http;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+
+/// The [AlloyChainProvider] is a concrete implementation of the [ChainProvider] trait, providing
+/// data over Ethereum JSON-RPC using an alloy provider as the backend.
+///
+/// **Note**:
+/// This provider fetches data using the `debug_getRawHeader`, `debug_getRawReceipts`, and
+/// `debug_getRawBlock` methods. The RPC must support this namespace.
+#[derive(Debug)]
+pub struct AlloyChainProvider<T: Provider<Http<reqwest::Client>>> {
+    inner: T,
+}
+
+impl<T: Provider<Http<reqwest::Client>>> AlloyChainProvider<T> {
+    /// Creates a new [AlloyChainProvider] with the given alloy provider.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T> {
+    /// Returns the block at the given number, or an error if the block does not exist in the data
+    /// source.
+    async fn block_info_by_number(&self, number: u64) -> Result<BlockInfo> {
+        let raw_header: Bytes = self
+            .inner
+            .client()
+            .request("debug_getRawHeader", [U64::from(number)])
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let header = Header::decode(&mut raw_header.as_ref()).map_err(|e| anyhow!(e))?;
+
+        Ok(BlockInfo {
+            hash: header.hash_slow(),
+            number,
+            parent_hash: header.parent_hash,
+            timestamp: header.timestamp,
+        })
+    }
+
+    /// Returns all receipts in the block with the given hash, or an error if the block does not
+    /// exist in the data source.
+    async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>> {
+        let raw_receipts: Vec<Bytes> = self
+            .inner
+            .client()
+            .request("debug_getRawReceipts", [hash])
+            .await
+            .map_err(|e| anyhow!(e))?;
+
+        raw_receipts
+            .iter()
+            .map(|r| {
+                let r = &mut r.as_ref();
+
+                // Skip the transaction type byte if it exists
+                if !r.is_empty() && r[0] <= TxType::Eip4844 as u8 {
+                    r.advance(1);
+                }
+
+                Ok(ReceiptWithBloom::decode(r).map_err(|e| anyhow!(e))?.receipt)
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+
+    /// Returns the [BlockInfo] and list of [TxEnvelope]s from the given block hash.
+    async fn block_info_and_transactions_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
+        let raw_block: Bytes = self
+            .inner
+            .client()
+            .request("debug_getRawBlock", [hash])
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let block = Block::decode(&mut raw_block.as_ref()).map_err(|e| anyhow!(e))?;
+
+        let block_info = BlockInfo {
+            hash: block.header.hash_slow(),
+            number: block.header.number,
+            parent_hash: block.header.parent_hash,
+            timestamp: block.header.timestamp,
+        };
+        Ok((block_info, block.body))
+    }
+}

--- a/crates/derive/src/alloy_providers.rs
+++ b/crates/derive/src/alloy_providers.rs
@@ -13,6 +13,10 @@ use alloy_rlp::{Buf, Decodable};
 use alloy_transport_http::Http;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use core::num::NonZeroUsize;
+use lru::LruCache;
+
+const CACHE_SIZE: usize = 16;
 
 /// The [AlloyChainProvider] is a concrete implementation of the [ChainProvider] trait, providing
 /// data over Ethereum JSON-RPC using an alloy provider as the backend.
@@ -22,19 +26,37 @@ use async_trait::async_trait;
 /// `debug_getRawBlock` methods. The RPC must support this namespace.
 #[derive(Debug)]
 pub struct AlloyChainProvider<T: Provider<Http<reqwest::Client>>> {
+    /// The inner Ethereum JSON-RPC provider.
     inner: T,
+    /// `block_info_by_number` LRU cache.
+    block_info_by_number_cache: LruCache<u64, BlockInfo>,
+    /// `block_info_by_number` LRU cache.
+    receipts_by_hash_cache: LruCache<B256, Vec<Receipt>>,
+    /// `block_info_and_transactions_by_hash` LRU cache.
+    block_info_and_transactions_by_hash_cache: LruCache<B256, (BlockInfo, Vec<TxEnvelope>)>,
 }
 
 impl<T: Provider<Http<reqwest::Client>>> AlloyChainProvider<T> {
     /// Creates a new [AlloyChainProvider] with the given alloy provider.
     pub fn new(inner: T) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            block_info_by_number_cache: LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()),
+            receipts_by_hash_cache: LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()),
+            block_info_and_transactions_by_hash_cache: LruCache::new(
+                NonZeroUsize::new(CACHE_SIZE).unwrap(),
+            ),
+        }
     }
 }
 
 #[async_trait]
 impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T> {
-    async fn block_info_by_number(&self, number: u64) -> Result<BlockInfo> {
+    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo> {
+        if let Some(block_info) = self.block_info_by_number_cache.get(&number) {
+            return Ok(*block_info);
+        }
+
         let raw_header: Bytes = self
             .inner
             .client()
@@ -43,15 +65,21 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
             .map_err(|e| anyhow!(e))?;
         let header = Header::decode(&mut raw_header.as_ref()).map_err(|e| anyhow!(e))?;
 
-        Ok(BlockInfo {
+        let block_info = BlockInfo {
             hash: header.hash_slow(),
             number,
             parent_hash: header.parent_hash,
             timestamp: header.timestamp,
-        })
+        };
+        self.block_info_by_number_cache.put(number, block_info);
+        Ok(block_info)
     }
 
-    async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>> {
+    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>> {
+        if let Some(receipts) = self.receipts_by_hash_cache.get(&hash) {
+            return Ok(receipts.clone());
+        }
+
         let raw_receipts: Vec<Bytes> = self
             .inner
             .client()
@@ -59,7 +87,7 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
             .await
             .map_err(|e| anyhow!(e))?;
 
-        raw_receipts
+        let receipts = raw_receipts
             .iter()
             .map(|r| {
                 let r = &mut r.as_ref();
@@ -71,13 +99,20 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
 
                 Ok(ReceiptWithBloom::decode(r).map_err(|e| anyhow!(e))?.receipt)
             })
-            .collect::<Result<Vec<_>>>()
+            .collect::<Result<Vec<_>>>()?;
+        self.receipts_by_hash_cache.put(hash, receipts.clone());
+        Ok(receipts)
     }
 
     async fn block_info_and_transactions_by_hash(
-        &self,
+        &mut self,
         hash: B256,
     ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
+        if let Some(block_info_and_txs) = self.block_info_and_transactions_by_hash_cache.get(&hash)
+        {
+            return Ok(block_info_and_txs.clone());
+        }
+
         let raw_block: Bytes = self
             .inner
             .client()
@@ -92,6 +127,7 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
             parent_hash: block.header.parent_hash,
             timestamp: block.header.timestamp,
         };
+        self.block_info_and_transactions_by_hash_cache.put(hash, (block_info, block.body.clone()));
         Ok((block_info, block.body))
     }
 }
@@ -104,25 +140,46 @@ impl<T: Provider<Http<reqwest::Client>>> ChainProvider for AlloyChainProvider<T>
 /// namespace.
 #[derive(Debug)]
 pub struct AlloyL2SafeHeadProvider<T: Provider<Http<reqwest::Client>>> {
+    /// The inner Ethereum JSON-RPC provider.
     inner: T,
+    /// The rollup configuration.
     rollup_config: Arc<RollupConfig>,
+    /// `payload_by_number` LRU cache.
+    payload_by_number_cache: LruCache<u64, ExecutionPayloadEnvelope>,
+    /// `l2_block_info_by_number` LRU cache.
+    l2_block_info_by_number_cache: LruCache<u64, L2BlockInfo>,
 }
 
 impl<T: Provider<Http<reqwest::Client>>> AlloyL2SafeHeadProvider<T> {
     /// Creates a new [AlloyL2SafeHeadProvider] with the given alloy provider and [RollupConfig].
     pub fn new(inner: T, rollup_config: Arc<RollupConfig>) -> Self {
-        Self { inner, rollup_config }
+        Self {
+            inner,
+            rollup_config,
+            payload_by_number_cache: LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()),
+            l2_block_info_by_number_cache: LruCache::new(NonZeroUsize::new(CACHE_SIZE).unwrap()),
+        }
     }
 }
 
 #[async_trait]
 impl<T: Provider<Http<reqwest::Client>>> L2SafeBlockFetcher for AlloyL2SafeHeadProvider<T> {
-    async fn l2_block_info_by_number(&self, number: u64) -> Result<L2BlockInfo> {
+    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
+        if let Some(l2_block_info) = self.l2_block_info_by_number_cache.get(&number) {
+            return Ok(*l2_block_info);
+        }
+
         let payload = self.payload_by_number(number).await?;
-        payload.to_l2_block_ref(self.rollup_config.as_ref())
+        let l2_block_info = payload.to_l2_block_ref(self.rollup_config.as_ref())?;
+        self.l2_block_info_by_number_cache.put(number, l2_block_info);
+        Ok(l2_block_info)
     }
 
-    async fn payload_by_number(&self, number: u64) -> Result<ExecutionPayloadEnvelope> {
+    async fn payload_by_number(&mut self, number: u64) -> Result<ExecutionPayloadEnvelope> {
+        if let Some(payload) = self.payload_by_number_cache.get(&number) {
+            return Ok(payload.clone());
+        }
+
         let raw_block: Bytes = self
             .inner
             .client()
@@ -130,6 +187,9 @@ impl<T: Provider<Http<reqwest::Client>>> L2SafeBlockFetcher for AlloyL2SafeHeadP
             .await
             .map_err(|e| anyhow!(e))?;
         let block = Block::decode(&mut raw_block.as_ref()).map_err(|e| anyhow!(e))?;
-        Ok(block.into())
+        let payload_envelope: ExecutionPayloadEnvelope = block.into();
+
+        self.payload_by_number_cache.put(number, payload_envelope.clone());
+        Ok(payload_envelope)
     }
 }

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -23,6 +23,9 @@ pub mod stages;
 pub mod traits;
 pub mod types;
 
+#[cfg(feature = "alloy-providers")]
+pub mod alloy_providers;
+
 /// The derivation pipeline is responsible for deriving L2 inputs from L1 data.
 #[derive(Debug, Clone, Copy)]
 pub struct DerivationPipeline;

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -23,7 +23,7 @@ pub mod stages;
 pub mod traits;
 pub mod types;
 
-#[cfg(feature = "alloy-providers")]
+#[cfg(feature = "online")]
 pub mod alloy_providers;
 
 /// The derivation pipeline is responsible for deriving L2 inputs from L1 data.

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -36,16 +36,6 @@ impl DerivationPipeline {
     where
         P: ChainProvider + Clone + Debug + Send,
     {
-        // let l1_traversal = L1Traversal::new(chain_provider, rollup_config.clone(),
-        // telemetry.clone()); let l1_retrieval = L1Retrieval::new(l1_traversal, dap_source,
-        // telemetry.clone()); let frame_queue = FrameQueue::new(l1_retrieval,
-        // telemetry.clone()); let channel_bank = ChannelBank::new(rollup_config.clone(),
-        // frame_queue, telemetry.clone()); let channel_reader =
-        // ChannelReader::new(channel_bank, telemetry.clone()); let batch_queue =
-        // BatchQueue::new(rollup_config.clone(), channel_reader, telemetry.clone(), fetcher);
-        // let attributes_queue = AttributesQueue::new(rollup_config.clone(), batch_queue,
-        // telemetry.clone(), builder);
-
-        unimplemented!()
+        unimplemented!("TODO: High-level pipeline composition helper.")
     }
 }

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::attributes_queue::AttributesProvider,
-    traits::{L2SafeBlockFetcher, LogLevel, OriginProvider, ResettableStage, TelemetryProvider},
+    traits::{L2ChainProvider, OriginProvider, ResettableStage},
     types::{
         Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, RollupConfig,
         SingleBatch, StageError, StageResult, SystemConfig,
@@ -42,7 +42,7 @@ pub trait BatchQueueProvider {
 pub struct BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginProvider + Debug,
-    BF: SafeBlockFetcher + Debug,
+    BF: L2ChainProvider + Debug,
 {
     /// The rollup config.
     cfg: RollupConfig,
@@ -72,7 +72,7 @@ where
 impl<P, BF> BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginProvider + Debug,
-    BF: SafeBlockFetcher + Debug,
+    BF: L2ChainProvider + Debug,
 {
     /// Creates a new [BatchQueue] stage.
     pub fn new(cfg: RollupConfig, prev: P, fetcher: BF) -> Self {
@@ -237,7 +237,7 @@ where
 impl<P, BF> AttributesProvider for BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginProvider + Send + Debug,
-    BF: SafeBlockFetcher + Send + Debug,
+    BF: L2ChainProvider + Send + Debug,
 {
     /// Returns the next valid batch upon the given safe head.
     /// Also returns the boolean that indicates if the batch is the last block in the batch.
@@ -362,7 +362,7 @@ where
 impl<P, BF> OriginProvider for BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginProvider + Debug,
-    BF: SafeBlockFetcher + Debug,
+    BF: L2ChainProvider + Debug,
 {
     fn origin(&self) -> Option<&BlockInfo> {
         self.prev.origin()
@@ -373,7 +373,7 @@ where
 impl<P, BF> ResettableStage for BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginProvider + Send + Debug,
-    BF: SafeBlockFetcher + Send + Debug,
+    BF: L2ChainProvider + Send + Debug,
 {
     async fn reset(&mut self, base: BlockInfo, _: &SystemConfig) -> StageResult<()> {
         // Copy over the Origin from the next stage.

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::attributes_queue::AttributesProvider,
-    traits::{OriginProvider, ResettableStage, SafeBlockFetcher},
+    traits::{L2SafeBlockFetcher, LogLevel, OriginProvider, ResettableStage, TelemetryProvider},
     types::{
         Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, RollupConfig,
         SingleBatch, StageError, StageResult, SystemConfig,

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -130,15 +130,9 @@ impl BatchReader {
     }
 }
 
-impl From<&[u8]> for BatchReader {
-    fn from(data: &[u8]) -> Self {
-        Self { data: Some(data.to_vec()), decompressed: Vec::new(), cursor: 0 }
-    }
-}
-
-impl From<Vec<u8>> for BatchReader {
-    fn from(data: Vec<u8>) -> Self {
-        Self { data: Some(data), decompressed: Vec::new(), cursor: 0 }
+impl<T: Into<Vec<u8>>> From<T> for BatchReader {
+    fn from(data: T) -> Self {
+        Self { data: Some(data.into()), decompressed: Vec::new(), cursor: 0 }
     }
 }
 

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -15,15 +15,15 @@ use async_trait::async_trait;
 pub trait ChainProvider {
     /// Returns the block at the given number, or an error if the block does not exist in the data
     /// source.
-    async fn block_info_by_number(&self, number: u64) -> Result<BlockInfo>;
+    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo>;
 
     /// Returns all receipts in the block with the given hash, or an error if the block does not
     /// exist in the data source.
-    async fn receipts_by_hash(&self, hash: B256) -> Result<Vec<Receipt>>;
+    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>>;
 
     /// Returns the [BlockInfo] and list of [TxEnvelope]s from the given block hash.
     async fn block_info_and_transactions_by_hash(
-        &self,
+        &mut self,
         hash: B256,
     ) -> Result<(BlockInfo, Vec<TxEnvelope>)>;
 }
@@ -33,11 +33,11 @@ pub trait ChainProvider {
 pub trait L2SafeBlockFetcher {
     /// Returns the L2 block info given a block number.
     /// Errors if the block does not exist.
-    async fn l2_block_info_by_number(&self, number: u64) -> Result<L2BlockInfo>;
+    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo>;
 
     /// Returns an execution payload for a given number.
     /// Errors if the execution payload does not exist.
-    async fn payload_by_number(&self, number: u64) -> Result<ExecutionPayloadEnvelope>;
+    async fn payload_by_number(&mut self, number: u64) -> Result<ExecutionPayloadEnvelope>;
 }
 
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -30,7 +30,7 @@ pub trait ChainProvider {
 
 /// Describes the functionality of a data source that fetches safe blocks.
 #[async_trait]
-pub trait L2SafeBlockFetcher {
+pub trait L2ChainProvider {
     /// Returns the L2 block info given a block number.
     /// Errors if the block does not exist.
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo>;

--- a/crates/derive/src/traits/ecrecover.rs
+++ b/crates/derive/src/traits/ecrecover.rs
@@ -4,10 +4,11 @@
 //! for signed types that can supply the original message hash for public key recovery. By default,
 //! it is implemented for [alloy_consensus::TxEnvelope] if the `k256` feature is enabled.
 
-use alloy_consensus::TxEnvelope;
 use alloy_primitives::Address;
 use anyhow::Result;
 
+#[cfg(feature = "k256")]
+use alloy_consensus::TxEnvelope;
 #[cfg(feature = "k256")]
 use alloy_primitives::{Signature, B256};
 #[cfg(feature = "k256")]

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -5,7 +5,7 @@ mod data_sources;
 pub use data_sources::*;
 
 mod stages;
-pub use stages::ResettableStage;
+pub use stages::{OriginProvider, ResettableStage};
 
 mod ecrecover;
 pub use ecrecover::SignedRecoverable;

--- a/crates/derive/src/traits/stages.rs
+++ b/crates/derive/src/traits/stages.rs
@@ -10,3 +10,9 @@ pub trait ResettableStage {
     /// Resets the derivation stage to its initial state.
     async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> StageResult<()>;
 }
+
+/// Provides a method for accessing the pipeline's current L1 origin.
+pub trait OriginProvider {
+    /// Returns the optional L1 [BlockInfo] origin.
+    fn origin(&self) -> Option<&BlockInfo>;
+}

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -1,7 +1,7 @@
 //! Data Sources Test Utilities
 
 use crate::{
-    traits::{ChainProvider, SafeBlockFetcher},
+    traits::{ChainProvider, L2SafeBlockFetcher},
     types::{BlockInfo, ExecutionPayloadEnvelope, L2BlockInfo},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -27,7 +27,7 @@ impl MockBlockFetcher {
 }
 
 #[async_trait]
-impl SafeBlockFetcher for MockBlockFetcher {
+impl L2SafeBlockFetcher for MockBlockFetcher {
     async fn l2_block_info_by_number(&self, number: u64) -> Result<L2BlockInfo> {
         self.blocks
             .iter()

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -1,7 +1,7 @@
 //! Data Sources Test Utilities
 
 use crate::{
-    traits::{ChainProvider, L2SafeBlockFetcher},
+    traits::{ChainProvider, L2ChainProvider},
     types::{BlockInfo, ExecutionPayloadEnvelope, L2BlockInfo},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -27,7 +27,7 @@ impl MockBlockFetcher {
 }
 
 #[async_trait]
-impl L2SafeBlockFetcher for MockBlockFetcher {
+impl L2ChainProvider for MockBlockFetcher {
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
         self.blocks
             .iter()

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -28,7 +28,7 @@ impl MockBlockFetcher {
 
 #[async_trait]
 impl L2SafeBlockFetcher for MockBlockFetcher {
-    async fn l2_block_info_by_number(&self, number: u64) -> Result<L2BlockInfo> {
+    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
         self.blocks
             .iter()
             .find(|b| b.block_info.number == number)
@@ -36,7 +36,7 @@ impl L2SafeBlockFetcher for MockBlockFetcher {
             .ok_or_else(|| anyhow::anyhow!("Block not found"))
     }
 
-    async fn payload_by_number(&self, number: u64) -> Result<ExecutionPayloadEnvelope> {
+    async fn payload_by_number(&mut self, number: u64) -> Result<ExecutionPayloadEnvelope> {
         self.payloads
             .iter()
             .find(|p| p.execution_payload.block_number == number)
@@ -84,7 +84,7 @@ impl TestChainProvider {
 
 #[async_trait]
 impl ChainProvider for TestChainProvider {
-    async fn block_info_by_number(&self, _number: u64) -> Result<BlockInfo> {
+    async fn block_info_by_number(&mut self, _number: u64) -> Result<BlockInfo> {
         if let Some((_, block)) = self.blocks.iter().find(|(n, _)| *n == _number) {
             Ok(*block)
         } else {
@@ -92,7 +92,7 @@ impl ChainProvider for TestChainProvider {
         }
     }
 
-    async fn receipts_by_hash(&self, _hash: B256) -> Result<Vec<Receipt>> {
+    async fn receipts_by_hash(&mut self, _hash: B256) -> Result<Vec<Receipt>> {
         if let Some((_, receipts)) = self.receipts.iter().find(|(h, _)| *h == _hash) {
             Ok(receipts.clone())
         } else {
@@ -101,7 +101,7 @@ impl ChainProvider for TestChainProvider {
     }
 
     async fn block_info_and_transactions_by_hash(
-        &self,
+        &mut self,
         hash: B256,
     ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
         let block = self

--- a/crates/derive/src/types/attributes.rs
+++ b/crates/derive/src/types/attributes.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{block::L2BlockInfo, payload::Withdrawals, RawTransaction};
+use super::{block::L2BlockInfo, RawTransaction, Withdrawal};
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256};
 
@@ -23,7 +23,7 @@ pub struct PayloadAttributes {
     /// Withdrawals to include into the block -- should be nil or empty depending on Shanghai
     /// enablement.
     #[cfg_attr(feature = "serde", serde(rename = "withdrawals"))]
-    pub withdrawals: Option<Withdrawals>,
+    pub withdrawals: Option<Vec<Withdrawal>>,
     /// Parent beacon block root optional extension in Dencun.
     #[cfg_attr(feature = "serde", serde(rename = "parentBeaconBlockRoot"))]
     pub parent_beacon_block_root: Option<B256>,

--- a/crates/derive/src/types/batch/mod.rs
+++ b/crates/derive/src/types/batch/mod.rs
@@ -3,7 +3,7 @@
 
 use super::DecodeError;
 use crate::{
-    traits::SafeBlockFetcher,
+    traits::L2SafeBlockFetcher,
     types::{BlockInfo, L2BlockInfo, RollupConfig},
 };
 use alloc::vec::Vec;
@@ -41,7 +41,7 @@ impl BatchWithInclusionBlock {
     /// One or more consecutive l1_blocks should be provided.
     /// In case of only a single L1 block, the decision whether a batch is valid may have to stay
     /// undecided.
-    pub fn check_batch<BF: SafeBlockFetcher>(
+    pub fn check_batch<BF: L2SafeBlockFetcher>(
         &self,
         cfg: &RollupConfig,
         l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/batch/mod.rs
+++ b/crates/derive/src/types/batch/mod.rs
@@ -3,7 +3,7 @@
 
 use super::DecodeError;
 use crate::{
-    traits::L2SafeBlockFetcher,
+    traits::L2ChainProvider,
     types::{BlockInfo, L2BlockInfo, RollupConfig},
 };
 use alloc::vec::Vec;
@@ -41,7 +41,7 @@ impl BatchWithInclusionBlock {
     /// One or more consecutive l1_blocks should be provided.
     /// In case of only a single L1 block, the decision whether a batch is valid may have to stay
     /// undecided.
-    pub fn check_batch<BF: L2SafeBlockFetcher>(
+    pub fn check_batch<BF: L2ChainProvider>(
         &self,
         cfg: &RollupConfig,
         l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -4,7 +4,7 @@
 
 use super::{SpanBatchError, SpanBatchTransactions};
 use crate::{
-    traits::L2SafeBlockFetcher,
+    traits::L2ChainProvider,
     types::{
         BatchValidity, BlockInfo, L2BlockInfo, RawSpanBatch, RollupConfig, SingleBatch,
         SpanBatchBits, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix,
@@ -41,7 +41,7 @@ impl SpanBatch {
     }
 
     /// Checks if the span batch is valid.
-    pub fn check_batch<BF: L2SafeBlockFetcher>(
+    pub fn check_batch<BF: L2ChainProvider>(
         &self,
         _cfg: &RollupConfig,
         _l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -4,7 +4,7 @@
 
 use super::{SpanBatchError, SpanBatchTransactions};
 use crate::{
-    traits::SafeBlockFetcher,
+    traits::L2SafeBlockFetcher,
     types::{
         BatchValidity, BlockInfo, L2BlockInfo, RawSpanBatch, RollupConfig, SingleBatch,
         SpanBatchBits, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix,
@@ -41,7 +41,7 @@ impl SpanBatch {
     }
 
     /// Checks if the span batch is valid.
-    pub fn check_batch<BF: SafeBlockFetcher>(
+    pub fn check_batch<BF: L2SafeBlockFetcher>(
         &self,
         _cfg: &RollupConfig,
         _l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/batch/span_batch/raw.rs
+++ b/crates/derive/src/types/batch/span_batch/raw.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use crate::{
-    traits::L2SafeBlockFetcher,
+    traits::L2ChainProvider,
     types::{
         BatchType, BatchValidity, BlockInfo, L2BlockInfo, RawTransaction, RollupConfig,
         SingleBatch, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix, SpanDecodingError,
@@ -33,7 +33,7 @@ impl RawSpanBatch {
     }
 
     /// Checks if the span batch is valid.
-    pub fn check_batch<BF: L2SafeBlockFetcher>(
+    pub fn check_batch<BF: L2ChainProvider>(
         &self,
         _cfg: &RollupConfig,
         _l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/batch/span_batch/raw.rs
+++ b/crates/derive/src/types/batch/span_batch/raw.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use crate::{
-    traits::SafeBlockFetcher,
+    traits::L2SafeBlockFetcher,
     types::{
         BatchType, BatchValidity, BlockInfo, L2BlockInfo, RawTransaction, RollupConfig,
         SingleBatch, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix, SpanDecodingError,
@@ -33,7 +33,7 @@ impl RawSpanBatch {
     }
 
     /// Checks if the span batch is valid.
-    pub fn check_batch<BF: SafeBlockFetcher>(
+    pub fn check_batch<BF: L2SafeBlockFetcher>(
         &self,
         _cfg: &RollupConfig,
         _l1_blocks: &[BlockInfo],

--- a/crates/derive/src/types/block.rs
+++ b/crates/derive/src/types/block.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::{Header, TxEnvelope};
-use alloy_primitives::{BlockHash, BlockNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
 
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 #[cfg(feature = "serde")]
@@ -117,6 +117,7 @@ pub struct Block {
 /// Withdrawal represents a validator withdrawal from the consensus layer.
 ///
 /// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodable, RlpDecodable)]
 pub struct Withdrawal {
     /// Monotonically increasing identifier issued by consensus layer.
@@ -124,7 +125,7 @@ pub struct Withdrawal {
     /// Index of validator associated with withdrawal.
     pub validator_index: u64,
     /// Target address for withdrawn ether.
-    pub address: alloy_primitives::Address,
+    pub address: Address,
     /// Value of the withdrawal in gwei.
     pub amount: u64,
 }

--- a/crates/derive/src/types/block.rs
+++ b/crates/derive/src/types/block.rs
@@ -1,7 +1,10 @@
 //! This module contains the various Block types.
 
+use alloc::vec::Vec;
+use alloy_consensus::{Header, TxEnvelope};
 use alloy_primitives::{BlockHash, BlockNumber, B256};
 
+use alloy_rlp::{RlpDecodable, RlpEncodable};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -91,4 +94,37 @@ pub enum BlockKind {
     Latest,
     /// The latest finalized block.
     Finalized,
+}
+
+/// Ethereum full block.
+///
+/// Withdrawals can be optionally included at the end of the RLP encoded message.
+///
+/// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
+#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub struct Block {
+    /// Block header.
+    pub header: Header,
+    /// Transactions in this block.
+    pub body: Vec<TxEnvelope>,
+    /// Ommers/uncles header.
+    pub ommers: Vec<Header>,
+    /// Block withdrawals.
+    pub withdrawals: Option<Vec<Withdrawal>>,
+}
+
+/// Withdrawal represents a validator withdrawal from the consensus layer.
+///
+/// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodable, RlpDecodable)]
+pub struct Withdrawal {
+    /// Monotonically increasing identifier issued by consensus layer.
+    pub index: u64,
+    /// Index of validator associated with withdrawal.
+    pub validator_index: u64,
+    /// Target address for withdrawn ether.
+    pub address: alloy_primitives::Address,
+    /// Value of the withdrawal in gwei.
+    pub amount: u64,
 }

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -31,7 +31,7 @@ pub use payload::{
 };
 
 mod block;
-pub use block::{BlockID, BlockInfo, BlockKind, L2BlockInfo};
+pub use block::{Block, BlockID, BlockInfo, BlockKind, L2BlockInfo, Withdrawal};
 
 mod blob;
 pub use blob::{Blob, BlobData, IndexedBlobHash};

--- a/crates/derive/src/types/payload.rs
+++ b/crates/derive/src/types/payload.rs
@@ -1,7 +1,9 @@
 //! Contains the execution payload type.
 
 use alloc::vec::Vec;
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_consensus::TxEnvelope;
+use alloy_primitives::{Address, Bloom, Bytes, B256};
+use anyhow::Result;
 
 /// Fixed and variable memory costs for a payload.
 /// ~1000 bytes per payload, with some margin for overhead like map data.
@@ -10,6 +12,9 @@ pub const PAYLOAD_MEM_FIXED_COST: u64 = 1000;
 /// Memory overhead per payload transaction.
 /// 24 bytes per tx overhead (size of slice header in memory).
 pub const PAYLOAD_TX_MEM_OVERHEAD: u64 = 24;
+
+use super::{Block, BlockInfo, L2BlockInfo, RollupConfig, Withdrawal};
+use alloy_rlp::{Decodable, Encodable};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -55,7 +60,7 @@ pub struct ExecutionPayload {
     pub receipts_root: B256,
     /// The logs bloom.
     #[cfg_attr(feature = "serde", serde(rename = "logsBloom"))]
-    pub logs_bloom: B256,
+    pub logs_bloom: Bloom,
     /// The mix hash.
     #[cfg_attr(feature = "serde", serde(rename = "prevRandao"))]
     pub prev_randao: B256,
@@ -73,10 +78,13 @@ pub struct ExecutionPayload {
     pub timestamp: u64,
     /// The extra data.
     #[cfg_attr(feature = "serde", serde(rename = "extraData"))]
-    pub extra_data: B256,
+    pub extra_data: Bytes,
     /// Base fee per gas.
-    #[cfg_attr(feature = "serde", serde(rename = "baseFeePerGas"))]
-    pub base_fee_per_gas: U256,
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")
+    )]
+    pub base_fee_per_gas: Option<u64>,
     /// Block hash.
     #[cfg_attr(feature = "serde", serde(rename = "blockHash"))]
     pub block_hash: B256,
@@ -84,17 +92,96 @@ pub struct ExecutionPayload {
     #[cfg_attr(feature = "serde", serde(rename = "transactions"))]
     pub transactions: Vec<Bytes>,
     /// The withdrawals.
-    #[cfg_attr(feature = "serde", serde(rename = "withdrawals"))]
-    pub withdrawals: Option<Withdrawals>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "withdrawals", skip_serializing_if = "Option::is_none")
+    )]
+    pub withdrawals: Option<Vec<Withdrawal>>,
     /// The  blob gas used.
-    #[cfg_attr(feature = "serde", serde(rename = "blobGasUsed"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "blobGasUsed", skip_serializing_if = "Option::is_none")
+    )]
     pub blob_gas_used: Option<u64>,
     /// The excess blob gas.
-    #[cfg_attr(feature = "serde", serde(rename = "excessBlobGas"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "excessBlobGas", skip_serializing_if = "Option::is_none")
+    )]
     pub excess_blob_gas: Option<u64>,
 }
 
-/// Withdrawal Type
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Withdrawals {}
+impl ExecutionPayloadEnvelope {
+    /// Converts the [ExecutionPayloadEnvelope] to an [L2BlockInfo], by checking against the L1
+    /// information transaction or the genesis block.
+    pub fn to_l2_block_ref(&self, rollup_config: &RollupConfig) -> Result<L2BlockInfo> {
+        let ExecutionPayloadEnvelope { execution_payload, .. } = self;
+
+        let (l1_origin, sequence_number) =
+            if execution_payload.block_number == rollup_config.genesis.l2.number {
+                if execution_payload.block_hash != rollup_config.genesis.l2.hash {
+                    anyhow::bail!("Invalid genesis hash");
+                }
+                (&rollup_config.genesis.l1, 0)
+            } else {
+                if execution_payload.transactions.is_empty() {
+                    anyhow::bail!(
+                        "L2 block is missing L1 info deposit transaction, block hash: {}",
+                        execution_payload.block_hash
+                    );
+                }
+                let _ = TxEnvelope::decode(&mut execution_payload.transactions[0].as_ref())
+                    .map_err(|e| anyhow::anyhow!(e))?;
+
+                todo!(
+                "Need Deposit transaction variant - see 'PayloadToBlockRef' in 'payload_util.go'"
+            );
+            };
+
+        Ok(L2BlockInfo {
+            block_info: BlockInfo {
+                hash: execution_payload.block_hash,
+                number: execution_payload.block_number,
+                parent_hash: execution_payload.parent_hash,
+                timestamp: execution_payload.timestamp,
+            },
+            l1_origin: *l1_origin,
+            seq_num: sequence_number,
+        })
+    }
+}
+
+impl From<Block> for ExecutionPayloadEnvelope {
+    fn from(block: Block) -> Self {
+        let Block { header, body, withdrawals, .. } = block;
+        Self {
+            execution_payload: ExecutionPayload {
+                parent_hash: header.parent_hash,
+                fee_recipient: header.beneficiary,
+                state_root: header.state_root,
+                receipts_root: header.receipts_root,
+                logs_bloom: header.logs_bloom,
+                prev_randao: header.difficulty.into(),
+                block_number: header.number,
+                gas_limit: header.gas_limit,
+                gas_used: header.gas_used,
+                timestamp: header.timestamp,
+                extra_data: header.extra_data.clone(),
+                base_fee_per_gas: header.base_fee_per_gas,
+                block_hash: header.hash_slow(),
+                transactions: body
+                    .into_iter()
+                    .map(|tx| {
+                        let mut buf = Vec::with_capacity(tx.length());
+                        tx.encode(&mut buf);
+                        buf.into()
+                    })
+                    .collect(),
+                withdrawals,
+                blob_gas_used: header.blob_gas_used,
+                excess_blob_gas: header.excess_blob_gas,
+            },
+            parent_beacon_block_root: header.parent_beacon_block_root,
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ lint-cannon:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/ethereum-optimism/kona/cannon-builder:main cargo +nightly clippy --workspace --all --all-features --target /mips-unknown-none.json -Zbuild-std -- -D warnings 
+    ghcr.io/ethereum-optimism/kona/cannon-builder:main cargo +nightly clippy --workspace --all --all-features --target /mips-unknown-none.json -Zbuild-std --exclude kona-derive -- -D warnings 
 
 # Lint the workspace (risc-v arch)
 lint-asterisc:
@@ -39,7 +39,7 @@ lint-asterisc:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/ethereum-optimism/kona/asterisc-builder:main cargo +nightly clippy --workspace --all --all-features --target riscv64gc-unknown-linux-gnu -Zbuild-std -- -D warnings 
+    ghcr.io/ethereum-optimism/kona/asterisc-builder:main cargo +nightly clippy --workspace --all --all-features --target riscv64gc-unknown-linux-gnu -Zbuild-std --exclude kona-derive -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:


### PR DESCRIPTION
## Overview

> [!NOTE]
> Blocked by need for `TxDeposit` variant in `TxEnvelope`.

Implements an online implementation of the `ChainProvider` trait, backed by an alloy RPC client. This provider is gated by the `alloy-providers` feature flag.