### PR TITLE
feat(common): Move from `RegisterSize` to native ptr size type

### DIFF
--- a/crates/common/src/asterisc/io.rs
+++ b/crates/common/src/asterisc/io.rs
@@ -1,4 +1,4 @@
-use crate::{asterisc::syscall, BasicKernelInterface, FileDescriptor, RegisterSize};
+use crate::{asterisc::syscall, BasicKernelInterface, FileDescriptor};
 use anyhow::Result;
 
 /// Concrete implementation of the [`KernelIO`] trait for the `riscv64` target architecture.
@@ -13,7 +13,7 @@ pub struct AsteriscIO;
 /// only the ones necessary for the [BasicKernelInterface] trait implementation. If an extension
 /// trait for the [BasicKernelInterface] trait is created for the `asterisc` kernel, this list
 /// should be extended accordingly.
-#[repr(u32)]
+#[repr(usize)]
 pub(crate) enum SyscallNumber {
     /// Sets the Exited and ExitCode states to true and $a0 respectively.
     Exit = 93,
@@ -24,31 +24,31 @@ pub(crate) enum SyscallNumber {
 }
 
 impl BasicKernelInterface for AsteriscIO {
-    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<RegisterSize> {
+    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<usize> {
         unsafe {
             Ok(syscall::syscall3(
-                SyscallNumber::Write as u64,
+                SyscallNumber::Write as usize,
                 fd.into(),
-                buf.as_ptr() as u64,
-                buf.len() as u64,
-            ) as RegisterSize)
+                buf.as_ptr() as usize,
+                buf.len(),
+            ))
         }
     }
 
-    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<RegisterSize> {
+    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<usize> {
         unsafe {
             Ok(syscall::syscall3(
-                SyscallNumber::Read as u64,
+                SyscallNumber::Read as usize,
                 fd.into(),
-                buf.as_ptr() as u64,
-                buf.len() as u64,
-            ) as RegisterSize)
+                buf.as_ptr() as usize,
+                buf.len(),
+            ))
         }
     }
 
-    fn exit(code: RegisterSize) -> ! {
+    fn exit(code: usize) -> ! {
         unsafe {
-            syscall::syscall1(SyscallNumber::Exit as u64, code);
+            syscall::syscall1(SyscallNumber::Exit as usize, code);
             panic!()
         }
     }

--- a/crates/common/src/asterisc/syscall.rs
+++ b/crates/common/src/asterisc/syscall.rs
@@ -15,13 +15,12 @@
 //! | %a5             | arg6               |
 //! | %a7             | syscall number     |
 
-use crate::RegisterSize;
 use core::arch::asm;
 
 /// Issues a raw system call with 1 argument. (e.g. exit)
 #[inline]
-pub(crate) unsafe fn syscall1(syscall_number: RegisterSize, arg1: RegisterSize) -> RegisterSize {
-    let mut ret: RegisterSize;
+pub(crate) unsafe fn syscall1(syscall_number: usize, arg1: usize) -> usize {
+    let mut ret: usize;
     asm!(
         "ecall",
         in("a7") syscall_number,
@@ -34,12 +33,12 @@ pub(crate) unsafe fn syscall1(syscall_number: RegisterSize, arg1: RegisterSize) 
 /// Issues a raw system call with 3 arguments. (e.g. read, write)
 #[inline]
 pub(crate) unsafe fn syscall3(
-    syscall_number: RegisterSize,
-    arg1: RegisterSize,
-    arg2: RegisterSize,
-    arg3: RegisterSize,
-) -> RegisterSize {
-    let mut ret: RegisterSize;
+    syscall_number: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+) -> usize {
+    let mut ret: usize;
     asm!(
         "ecall",
         in("a7") syscall_number,

--- a/crates/common/src/cannon/io.rs
+++ b/crates/common/src/cannon/io.rs
@@ -1,4 +1,4 @@
-use crate::{cannon::syscall, BasicKernelInterface, FileDescriptor, RegisterSize};
+use crate::{cannon::syscall, BasicKernelInterface, FileDescriptor};
 use anyhow::{anyhow, Result};
 
 /// Concrete implementation of the [BasicKernelInterface] trait for the `MIPS32rel1` target
@@ -14,7 +14,7 @@ pub struct CannonIO;
 /// only the ones necessary for the [BasicKernelInterface] trait implementation. If an extension
 /// trait for the [BasicKernelInterface] trait is created for the `Cannon` kernel, this list should
 /// be extended accordingly.
-#[repr(u32)]
+#[repr(usize)]
 pub(crate) enum SyscallNumber {
     /// Sets the Exited and ExitCode states to true and $a0 respectively.
     Exit = 4246,
@@ -25,33 +25,33 @@ pub(crate) enum SyscallNumber {
 }
 
 impl BasicKernelInterface for CannonIO {
-    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<RegisterSize> {
+    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<usize> {
         unsafe {
             syscall::syscall3(
-                SyscallNumber::Write as u32,
+                SyscallNumber::Write as usize,
                 fd.into(),
-                buf.as_ptr() as u32,
-                buf.len() as u32,
+                buf.as_ptr() as usize,
+                buf.len(),
             )
             .map_err(|e| anyhow!("Syscall Error: {e}"))
         }
     }
 
-    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<RegisterSize> {
+    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<usize> {
         unsafe {
             syscall::syscall3(
-                SyscallNumber::Read as u32,
+                SyscallNumber::Read as usize,
                 fd.into(),
-                buf.as_ptr() as u32,
-                buf.len() as u32,
+                buf.as_ptr() as usize,
+                buf.len(),
             )
             .map_err(|e| anyhow!("Syscall Error: {e}"))
         }
     }
 
-    fn exit(code: RegisterSize) -> ! {
+    fn exit(code: usize) -> ! {
         unsafe {
-            syscall::syscall1(SyscallNumber::Exit as RegisterSize, code);
+            syscall::syscall1(SyscallNumber::Exit as usize, code);
             panic!()
         }
     }

--- a/crates/common/src/cannon/syscall.rs
+++ b/crates/common/src/cannon/syscall.rs
@@ -34,14 +34,13 @@
 //!
 //! All temporary registers are clobbered (8-15, 24-25).
 
-use crate::RegisterSize;
 use core::arch::asm;
 
 /// Issues a raw system call with 1 argument. (e.g. exit)
 #[inline]
-pub(crate) unsafe fn syscall1(n: RegisterSize, arg1: RegisterSize) -> RegisterSize {
-    let mut err: RegisterSize;
-    let mut ret: RegisterSize;
+pub(crate) unsafe fn syscall1(n: usize, arg1: usize) -> usize {
+    let mut err: usize;
+    let mut ret: usize;
     asm!(
         "syscall",
         inlateout("$2") n => ret,
@@ -67,13 +66,13 @@ pub(crate) unsafe fn syscall1(n: RegisterSize, arg1: RegisterSize) -> RegisterSi
 /// Issues a raw system call with 3 arguments. (e.g. read, write)
 #[inline]
 pub(crate) unsafe fn syscall3(
-    n: RegisterSize,
-    arg1: RegisterSize,
-    arg2: RegisterSize,
-    arg3: RegisterSize,
-) -> Result<RegisterSize, i32> {
-    let mut err: RegisterSize;
-    let mut ret: RegisterSize;
+    n: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+) -> Result<usize, i32> {
+    let mut err: usize;
+    let mut ret: usize;
     asm!(
         "syscall",
         inlateout("$2") n => ret,
@@ -97,7 +96,7 @@ pub(crate) unsafe fn syscall3(
 
     let value = (err == 0).then_some(ret).unwrap_or_else(|| ret.wrapping_neg());
 
-    (value <= -4096isize as RegisterSize).then_some(value).ok_or_else(|| {
+    (value <= -4096isize as usize).then_some(value).ok_or_else(|| {
         // Truncation of the error value is guaranteed to never occur due to
         // the above check. This is the same check that musl uses:
         // https://git.musl-libc.org/cgit/musl/tree/src/internal/syscall_ret.c?h=v1.1.15

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -15,7 +15,7 @@ mod traits;
 pub use traits::BasicKernelInterface;
 
 mod types;
-pub use types::{FileDescriptor, RegisterSize};
+pub use types::FileDescriptor;
 
 mod executor;
 pub use executor::block_on;

--- a/crates/common/src/traits/basic.rs
+++ b/crates/common/src/traits/basic.rs
@@ -1,7 +1,7 @@
 //! Defines the [BasicKernelInterface] trait, which describes the functionality of several system
 //! calls inside of the FPVM kernel.
 
-use crate::{FileDescriptor, RegisterSize};
+use crate::FileDescriptor;
 use anyhow::Result;
 
 /// The [BasicKernelInterface] trait describes the functionality of several core system calls inside
@@ -13,12 +13,12 @@ use anyhow::Result;
 /// trait should be created that extends this trait.
 pub trait BasicKernelInterface {
     /// Write the given buffer to the given file descriptor.
-    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<RegisterSize>;
+    fn write(fd: FileDescriptor, buf: &[u8]) -> Result<usize>;
 
     /// Read from the given file descriptor into the passed buffer.
-    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<RegisterSize>;
+    fn read(fd: FileDescriptor, buf: &mut [u8]) -> Result<usize>;
 
     /// Exit the process with the given exit code. The implementation of this function
     /// should always panic after invoking the `EXIT` syscall.
-    fn exit(code: RegisterSize) -> !;
+    fn exit(code: usize) -> !;
 }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,20 +1,5 @@
 //! This module contains the local types for the `kona-common` crate.
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(target_arch = "mips")] {
-        /// The size of the `mips32` target architecture's registers.
-        pub type RegisterSize = u32;
-    } else if #[cfg(target_arch = "riscv64")] {
-        /// The size of the `riscv64` target architecture's registers.
-        pub type RegisterSize = u64;
-    } else {
-        /// The size of the native target architecture's registers.
-        pub type RegisterSize = u64;
-    }
-}
-
 /// File descriptors available to the `client` within the FPVM kernel.
 #[derive(Debug, Clone, Copy)]
 pub enum FileDescriptor {
@@ -33,10 +18,10 @@ pub enum FileDescriptor {
     /// Write-only. Used to request pre-images.
     PreimageWrite,
     /// Other file descriptor, usually used for testing purposes.
-    Wildcard(RegisterSize),
+    Wildcard(usize),
 }
 
-impl From<FileDescriptor> for RegisterSize {
+impl From<FileDescriptor> for usize {
     fn from(fd: FileDescriptor) -> Self {
         match fd {
             FileDescriptor::StdIn => 0,


### PR DESCRIPTION
## Overview

Removes the `RegisterSize` type in `kona-common` in favor of `usize`, which natively represents the pointer size of the target. https://doc.rust-lang.org/stable/std/primitive.usize.html