### PR TITLE
chore(derive): Derive full `SpanBatch` in channel reader

### DIFF
--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -36,7 +36,7 @@ pub struct SpanBatch {
 
 impl SpanBatch {
     /// Returns the timestamp for the first batch in the span.
-    pub fn get_timestamp(&self) -> u64 {
+    pub fn timestamp(&self) -> u64 {
         self.batches[0].timestamp
     }
 
@@ -87,7 +87,7 @@ impl SpanBatch {
     /// stage.
     pub fn get_singular_batches(
         &self,
-        l1_origins: Vec<BlockInfo>,
+        l1_origins: &[BlockInfo],
         l2_safe_head: L2BlockInfo,
     ) -> Result<Vec<SingleBatch>, SpanBatchError> {
         let mut single_batches = Vec::new();

--- a/crates/derive/src/types/batch/span_batch/raw.rs
+++ b/crates/derive/src/types/batch/span_batch/raw.rs
@@ -2,12 +2,9 @@
 
 use alloc::vec::Vec;
 
-use crate::{
-    traits::L2ChainProvider,
-    types::{
-        BatchType, BatchValidity, BlockInfo, L2BlockInfo, RawTransaction, RollupConfig,
-        SingleBatch, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix, SpanDecodingError,
-    },
+use crate::types::{
+    BatchType, RawTransaction, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix,
+    SpanDecodingError,
 };
 
 use super::{SpanBatch, SpanBatchError};
@@ -30,27 +27,6 @@ impl RawSpanBatch {
     /// Returns the timestamp for the span batch.
     pub fn timestamp(&self) -> u64 {
         self.prefix.rel_timestamp
-    }
-
-    /// Checks if the span batch is valid.
-    pub fn check_batch<BF: L2ChainProvider>(
-        &self,
-        _cfg: &RollupConfig,
-        _l1_blocks: &[BlockInfo],
-        _l2_safe_head: L2BlockInfo,
-        _inclusion_block: &BlockInfo,
-        _fetcher: &BF,
-    ) -> BatchValidity {
-        unimplemented!()
-    }
-
-    /// Derives [SingleBatch]s from the span batch.
-    pub fn get_singular_batches(
-        &self,
-        _l1_blocks: &[BlockInfo],
-        _parent: L2BlockInfo,
-    ) -> Vec<SingleBatch> {
-        unimplemented!()
     }
 
     /// Encodes the [RawSpanBatch] into a writer.


### PR DESCRIPTION
## Overview

Swaps over to deriving the full `SpanBatch`, now that the implementation of `RawSpanBatch` is mostly stable.