### PR TITLE
feat(derive): `L2ChainProvider` w/ `op-alloy-consensus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+source = "git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding#842bf916e8242a163cb4375cce56f3ee59a340e9"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,13 +43,15 @@ dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding)",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding)",
+ "serde",
  "sha2",
 ]
 
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding#842bf916e8242a163cb4375cce56f3ee59a340e9"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
 dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
  "alloy-primitives",
@@ -68,6 +70,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.1.0 (git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding)",
+ "c-kzg",
+ "serde",
 ]
 
 [[package]]
@@ -1582,6 +1586,8 @@ dependencies = [
  "alloy-eips 0.1.0 (git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding)",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/clabby/alloy?branch=cl/consensus-expose-encoding)",
+ "serde",
 ]
 
 [[package]]

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -19,6 +19,7 @@ alloy-primitives = { version = "0.7.0", default-features = false, features = ["r
 alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }
 alloy-sol-types = { version = "0.7.0", default-features = false }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
+op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
 async-trait = "0.1.77"
 hashbrown = "0.14.3"
@@ -42,8 +43,8 @@ tracing-subscriber = "0.3.18"
 
 [features]
 default = ["serde", "k256"]
-serde = ["dep:serde", "alloy-primitives/serde"]
-k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
+serde = ["dep:serde", "alloy-primitives/serde", "alloy-consensus/serde", "op-alloy-consensus/serde"]
+k256 = ["alloy-primitives/k256", "alloy-consensus/k256", "op-alloy-consensus/k256"]
 online = [
   "dep:alloy-provider",
   "dep:alloy-transport-http",

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -19,7 +19,6 @@ alloy-primitives = { version = "0.7.0", default-features = false, features = ["r
 alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }
 alloy-sol-types = { version = "0.7.0", default-features = false }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
-op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
 async-trait = "0.1.77"
 hashbrown = "0.14.3"

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -3,8 +3,8 @@
 use crate::{
     traits::{OriginProvider, ResettableStage},
     types::{
-        AttributesWithParent, BlockInfo, L2BlockInfo, PayloadAttributes, ResetError, RollupConfig,
-        SingleBatch, StageError, StageResult, SystemConfig,
+        BlockInfo, L2AttributesWithParent, L2BlockInfo, L2PayloadAttributes, ResetError,
+        RollupConfig, SingleBatch, StageError, StageResult, SystemConfig,
     },
 };
 use alloc::boxed::Box;
@@ -29,7 +29,7 @@ pub trait AttributesProvider {
 }
 
 /// [AttributesQueue] accepts batches from the [BatchQueue] stage
-/// and transforms them into [PayloadAttributes]. The outputted payload
+/// and transforms them into [L2PayloadAttributes]. The outputted payload
 /// attributes cannot be buffered because each batch->attributes transformation
 /// pulls in data about the current L2 safe head.
 ///
@@ -95,7 +95,7 @@ where
         Ok(populated_attributes)
     }
 
-    /// Creates the next attributes, transforming a [SingleBatch] into [PayloadAttributes].
+    /// Creates the next attributes, transforming a [SingleBatch] into [L2PayloadAttributes].
     /// This sets `no_tx_pool` and appends the batched txs to the attributes tx list.
     pub async fn create_next_attributes(
         &mut self,

--- a/crates/derive/src/stages/attributes_queue/builder.rs
+++ b/crates/derive/src/stages/attributes_queue/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     params::SEQUENCER_FEE_VAULT_ADDRESS,
     traits::ChainProvider,
     types::{
-        BlockID, BuilderError, EcotoneTransactionBuilder, L2BlockInfo, PayloadAttributes,
+        BlockID, BuilderError, EcotoneTransactionBuilder, L2BlockInfo, L2PayloadAttributes,
         RawTransaction, RollupConfig, SystemConfig,
     },
 };
@@ -17,10 +17,10 @@ use async_trait::async_trait;
 /// that can be used to construct an L2 Block containing only deposits.
 #[async_trait]
 pub trait AttributesBuilder {
-    /// Prepares a template [PayloadAttributes] that is ready to be used to build an L2 block.
+    /// Prepares a template [L2PayloadAttributes] that is ready to be used to build an L2 block.
     /// The block will contain deposits only, on top of the given L2 parent, with the L1 origin
     /// set to the given epoch.
-    /// By default, the [PayloadAttributes] template will have `no_tx_pool` set to true,
+    /// By default, the [L2PayloadAttributes] template will have `no_tx_pool` set to true,
     /// and no sequencer transactions. The caller has to modify the template to add transactions.
     /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
     /// batch transactions as the verifier.
@@ -28,7 +28,7 @@ pub trait AttributesBuilder {
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockID,
-    ) -> Result<PayloadAttributes, BuilderError>;
+    ) -> Result<L2PayloadAttributes, BuilderError>;
 }
 
 /// The [SystemConfigL2Fetcher] fetches the system config by L2 hash.
@@ -73,7 +73,7 @@ where
         &mut self,
         l2_parent: L2BlockInfo,
         epoch: BlockID,
-    ) -> Result<PayloadAttributes, BuilderError> {
+    ) -> Result<L2PayloadAttributes, BuilderError> {
         let l1_header;
         let deposit_transactions: Vec<RawTransaction>;
         // let mut sequence_number = 0u64;
@@ -151,7 +151,7 @@ where
             parent_beacon_root = Some(l1_header.parent_beacon_block_root.unwrap_or_default());
         }
 
-        Ok(PayloadAttributes {
+        Ok(L2PayloadAttributes {
             timestamp: next_l2_time,
             prev_randao: l1_header.mix_hash,
             fee_recipient: SEQUENCER_FEE_VAULT_ADDRESS,

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -4,8 +4,8 @@ use crate::{
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
     traits::OriginProvider,
     types::{
-        BlockID, BlockInfo, BuilderError, L2BlockInfo, PayloadAttributes, SingleBatch, StageError,
-        StageResult,
+        BlockID, BlockInfo, BuilderError, L2BlockInfo, L2PayloadAttributes, SingleBatch,
+        StageError, StageResult,
     },
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -25,7 +25,7 @@ impl AttributesBuilder for MockAttributesBuilder {
         &mut self,
         _l2_parent: L2BlockInfo,
         _epoch: BlockID,
-    ) -> Result<PayloadAttributes, BuilderError> {
+    ) -> Result<L2PayloadAttributes, BuilderError> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),
             Some(Err(err)) => Err(BuilderError::Custom(err)),

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 #[derive(Debug, Default)]
 pub struct MockAttributesBuilder {
     /// The attributes to return.
-    pub attributes: Vec<anyhow::Result<PayloadAttributes>>,
+    pub attributes: Vec<anyhow::Result<L2PayloadAttributes>>,
 }
 
 #[async_trait]

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -2,7 +2,7 @@
 //! pipeline's stages.
 
 use crate::types::{
-    Blob, BlockInfo, ExecutionPayloadEnvelope, IndexedBlobHash, L2BlockInfo, StageResult,
+    Blob, BlockInfo, IndexedBlobHash, L2BlockInfo, L2ExecutionPayloadEnvelope, StageResult,
 };
 use alloc::{boxed::Box, fmt::Debug, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
@@ -40,7 +40,7 @@ pub trait L2ChainProvider {
 
     /// Returns an execution payload for a given number.
     /// Errors if the execution payload does not exist.
-    async fn payload_by_number(&mut self, number: u64) -> Result<ExecutionPayloadEnvelope>;
+    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope>;
 }
 
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     traits::{ChainProvider, L2ChainProvider},
-    types::{BlockInfo, ExecutionPayloadEnvelope, L2BlockInfo},
+    types::{BlockInfo, L2BlockInfo, L2ExecutionPayloadEnvelope},
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
@@ -16,12 +16,12 @@ pub struct MockBlockFetcher {
     /// Blocks
     pub blocks: Vec<L2BlockInfo>,
     /// Payloads
-    pub payloads: Vec<ExecutionPayloadEnvelope>,
+    pub payloads: Vec<L2ExecutionPayloadEnvelope>,
 }
 
 impl MockBlockFetcher {
     /// Creates a new [MockBlockFetcher] with the given origin and batches.
-    pub fn new(blocks: Vec<L2BlockInfo>, payloads: Vec<ExecutionPayloadEnvelope>) -> Self {
+    pub fn new(blocks: Vec<L2BlockInfo>, payloads: Vec<L2ExecutionPayloadEnvelope>) -> Self {
         Self { blocks, payloads }
     }
 }
@@ -36,7 +36,7 @@ impl L2ChainProvider for MockBlockFetcher {
             .ok_or_else(|| anyhow::anyhow!("Block not found"))
     }
 
-    async fn payload_by_number(&mut self, number: u64) -> Result<ExecutionPayloadEnvelope> {
+    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope> {
         self.payloads
             .iter()
             .find(|p| p.execution_payload.block_number == number)

--- a/crates/derive/src/types/attributes.rs
+++ b/crates/derive/src/types/attributes.rs
@@ -10,7 +10,7 @@ use alloy_primitives::{Address, B256};
 /// Payload attributes.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct PayloadAttributes {
+pub struct L2PayloadAttributes {
     /// Value for the timestamp field of the new payload.
     #[cfg_attr(feature = "serde", serde(rename = "timestamp"))]
     pub timestamp: u64,
@@ -42,23 +42,27 @@ pub struct PayloadAttributes {
 
 /// Payload Attributes with parent block reference.
 #[derive(Debug, Clone, PartialEq)]
-pub struct AttributesWithParent {
+pub struct L2AttributesWithParent {
     /// The payload attributes.
-    pub attributes: PayloadAttributes,
+    pub attributes: L2PayloadAttributes,
     /// The parent block reference.
     pub parent: L2BlockInfo,
     /// Whether the current batch is the last in its span.
     pub is_last_in_span: bool,
 }
 
-impl AttributesWithParent {
+impl L2AttributesWithParent {
     /// Create a new [AttributesWithParent] instance.
-    pub fn new(attributes: PayloadAttributes, parent: L2BlockInfo, is_last_in_span: bool) -> Self {
+    pub fn new(
+        attributes: L2PayloadAttributes,
+        parent: L2BlockInfo,
+        is_last_in_span: bool,
+    ) -> Self {
         Self { attributes, parent, is_last_in_span }
     }
 
     /// Returns the payload attributes.
-    pub fn attributes(&self) -> &PayloadAttributes {
+    pub fn attributes(&self) -> &L2PayloadAttributes {
         &self.attributes
     }
 

--- a/crates/derive/src/types/block.rs
+++ b/crates/derive/src/types/block.rs
@@ -5,6 +5,7 @@ use alloy_consensus::{Header, TxEnvelope};
 use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
 
 use alloy_rlp::{RlpDecodable, RlpEncodable};
+use op_alloy_consensus::OpTxEnvelope;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -108,6 +109,24 @@ pub struct Block {
     pub header: Header,
     /// Transactions in this block.
     pub body: Vec<TxEnvelope>,
+    /// Ommers/uncles header.
+    pub ommers: Vec<Header>,
+    /// Block withdrawals.
+    pub withdrawals: Option<Vec<Withdrawal>>,
+}
+
+/// OP Stack full block.
+///
+/// Withdrawals can be optionally included at the end of the RLP encoded message.
+///
+/// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
+#[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, RlpDecodable)]
+#[rlp(trailing)]
+pub struct OpBlock {
+    /// Block header.
+    pub header: Header,
+    /// Transactions in this block.
+    pub body: Vec<OpTxEnvelope>,
     /// Ommers/uncles header.
     pub ommers: Vec<Header>,
     /// Block withdrawals.

--- a/crates/derive/src/types/l1_block_info.rs
+++ b/crates/derive/src/types/l1_block_info.rs
@@ -1,6 +1,6 @@
 //! This module contains the [L1BlockInfoTx] type, and various encoding / decoding methods for it.
 
-use super::{DepositSourceDomain, L1InfoDepositSource, RollupConfig, SystemConfig};
+use super::{BlockID, DepositSourceDomain, L1InfoDepositSource, RollupConfig, SystemConfig};
 use alloc::vec::Vec;
 use alloy_consensus::Header;
 use alloy_primitives::{address, Address, Bytes, TxKind, B256, U256};
@@ -228,6 +228,26 @@ impl L1BlockInfoTx {
         match self {
             Self::Ecotone(ecotone_tx) => ecotone_tx.encode_calldata(),
             Self::Bedrock(bedrock_tx) => bedrock_tx.encode_calldata(),
+        }
+    }
+
+    /// Returns the L1 [BlockID] for the info transaction.
+    pub fn id(&self) -> BlockID {
+        match self {
+            Self::Ecotone(L1BlockInfoEcotone { number, block_hash, .. }) => {
+                BlockID { number: *number, hash: *block_hash }
+            }
+            Self::Bedrock(L1BlockInfoBedrock { number, block_hash, .. }) => {
+                BlockID { number: *number, hash: *block_hash }
+            }
+        }
+    }
+
+    /// Returns the sequence number for the info transaction
+    pub fn sequence_number(&self) -> u64 {
+        match self {
+            Self::Ecotone(L1BlockInfoEcotone { sequence_number, .. }) => *sequence_number,
+            Self::Bedrock(L1BlockInfoBedrock { sequence_number, .. }) => *sequence_number,
         }
     }
 }

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -9,7 +9,7 @@ use alloy_primitives::Bytes;
 use alloy_rlp::{Decodable, Encodable};
 
 mod attributes;
-pub use attributes::{AttributesWithParent, PayloadAttributes};
+pub use attributes::{L2AttributesWithParent, L2PayloadAttributes};
 
 mod system_config;
 pub use system_config::{SystemAccounts, SystemConfig, SystemConfigUpdateType};
@@ -34,11 +34,11 @@ pub use ecotone::*;
 
 mod payload;
 pub use payload::{
-    ExecutionPayload, ExecutionPayloadEnvelope, PAYLOAD_MEM_FIXED_COST, PAYLOAD_TX_MEM_OVERHEAD,
+    L2ExecutionPayload, L2ExecutionPayloadEnvelope, PAYLOAD_MEM_FIXED_COST, PAYLOAD_TX_MEM_OVERHEAD,
 };
 
 mod block;
-pub use block::{Block, BlockID, BlockInfo, BlockKind, L2BlockInfo, Withdrawal};
+pub use block::{Block, BlockID, BlockInfo, BlockKind, L2BlockInfo, OpBlock, Withdrawal};
 
 mod l1_block_info;
 pub use l1_block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};


### PR DESCRIPTION
## Overview

Updates the `L2ChainProvider` implementation to use the proper OP Stack types, and completes the block info / payload by hash fetching.
 
### TODO
- [x] Pull in `op-alloy-consensus` on the fork to update types
    - [ ] Once upstream PR is merged, move to `op-alloy` repository.
- [x] Complete `to_l2_block_ref`; Requires `L1BlockInfo` decoding from calldata.
    - [x] Move `L1BlockInfo` from `reth` into `kona-derive`/`op-alloy`