### PR TITLE
chore(ci): Fail CI on doclint failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,6 @@ jobs:
   cargo-doc:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -90,7 +89,6 @@ jobs:
         with:
           cache-on-failure: true
       - name: doclint
-        continue-on-error: true
         run: just lint-docs
       - name: doctest
         run: just test-docs

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -19,6 +19,8 @@ mod builder;
 pub use builder::{AttributesBuilder, StatefulAttributesBuilder};
 
 /// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
+///
+/// [BatchQueue]: crate::stages::BatchQueue
 #[async_trait]
 pub trait AttributesProvider {
     /// Returns the next valid batch upon the given safe head.
@@ -38,6 +40,8 @@ pub trait AttributesProvider {
 ///
 /// This stage can be reset by clearing its batch buffer.
 /// This stage does not need to retain any references to L1 blocks.
+///
+/// [BatchQueue]: crate::stages::BatchQueue
 #[derive(Debug)]
 pub struct AttributesQueue<P, AB>
 where

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -21,6 +21,8 @@ pub trait BatchQueueProvider {
     /// This function can only be called once while the stage is in progress, and will return
     /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
     /// complete and the batch has been consumed, an [StageError::Eof] error is returned.
+    ///
+    /// [ChannelReader]: crate::stages::ChannelReader
     async fn next_batch(&mut self) -> StageResult<Batch>;
 }
 
@@ -62,7 +64,9 @@ where
     /// A set of batches in order from when we've seen them.
     batches: Vec<BatchWithInclusionBlock>,
 
-    /// A set of cached [SingleBatche]s derived from [SpanBatch]s.
+    /// A set of cached [SingleBatch]es derived from [SpanBatch]es.
+    ///
+    /// [SpanBatch]: crate::types::SpanBatch
     next_spans: Vec<SingleBatch>,
 
     /// Used to validate the batches.

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -18,6 +18,8 @@ use tracing::{debug, warn};
 #[async_trait]
 pub trait ChannelBankProvider {
     /// Retrieves the next [Frame] from the [FrameQueue] stage.
+    ///
+    /// [FrameQueue]: crate::stages::FrameQueue
     async fn next_frame(&mut self) -> StageResult<Frame>;
 }
 

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -26,6 +26,8 @@ pub trait FrameQueueProvider {
 
 /// The [FrameQueue] stage of the derivation pipeline.
 /// This stage takes the output of the [L1Retrieval] stage and parses it into frames.
+///
+/// [L1Retrieval]: crate::stages::L1Retrieval
 #[derive(Debug)]
 pub struct FrameQueue<P>
 where
@@ -42,6 +44,8 @@ where
     P: FrameQueueProvider + OriginProvider + Debug,
 {
     /// Create a new [FrameQueue] stage with the given previous [L1Retrieval] stage.
+    ///
+    /// [L1Retrieval]: crate::stages::L1Retrieval
     pub fn new(prev: P) -> Self {
         Self { prev, queue: VecDeque::new() }
     }

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -17,6 +17,8 @@ pub trait L1RetrievalProvider {
     /// This function can only be called once while the stage is in progress, and will return
     /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
     /// complete and the [BlockInfo] has been consumed, an [StageError::Eof] error is returned.
+    ///
+    /// [L1Traversal]: crate::stages::L1Traversal
     fn next_l1_block(&mut self) -> StageResult<Option<BlockInfo>>;
 
     /// Returns the batcher [Address] from the [crate::types::SystemConfig].
@@ -24,10 +26,12 @@ pub trait L1RetrievalProvider {
 }
 
 /// The [L1Retrieval] stage of the derivation pipeline.
-/// For each L1 [BlockInfo] pulled from the [L1Traversal] stage,
-/// [L1Retrieval] fetches the associated data from a specified
-/// [DataAvailabilityProvider]. This data is returned as a generic
+/// For each L1 [BlockInfo] pulled from the [L1Traversal] stage, [L1Retrieval] fetches the
+/// associated data from a specified [DataAvailabilityProvider]. This data is returned as a generic
 /// [DataIter] that can be iterated over.
+///
+/// [L1Traversal]: crate::stages::L1Traversal
+/// [DataIter]: crate::traits::DataAvailabilityProvider::DataIter
 #[derive(Debug)]
 pub struct L1Retrieval<DAP, P>
 where
@@ -47,8 +51,10 @@ where
     DAP: DataAvailabilityProvider,
     P: L1RetrievalProvider + OriginProvider,
 {
-    /// Creates a new [L1Retrieval] stage with the previous [L1Traversal]
-    /// stage and given [DataAvailabilityProvider].
+    /// Creates a new [L1Retrieval] stage with the previous [L1Traversal] stage and given
+    /// [DataAvailabilityProvider].
+    ///
+    /// [L1Traversal]: crate::stages::L1Traversal
     pub fn new(prev: P, provider: DAP) -> Self {
         Self { prev, provider, data: None }
     }

--- a/crates/derive/src/types/ecotone.rs
+++ b/crates/derive/src/types/ecotone.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 //! Module containing a [Transaction] builder for the Ecotone network updgrade transactions.
+//!
+//! [Transaction]: alloy_consensus::Transaction
 
 use crate::types::{RawTransaction, UpgradeDepositSource};
 use alloc::{string::String, vec, vec::Vec};

--- a/crates/derive/src/types/errors.rs
+++ b/crates/derive/src/types/errors.rs
@@ -190,7 +190,9 @@ impl Display for DecodeError {
     }
 }
 
-/// An [AttributeBuilder] Error.
+/// An [AttributesBuilder] Error.
+///
+/// [AttributesBuilder]: crate::stages::AttributesBuilder
 #[derive(Debug)]
 pub enum BuilderError {
     /// Mismatched blocks.
@@ -198,6 +200,8 @@ pub enum BuilderError {
     /// Mismatched blocks for the start of an Epoch.
     BlockMismatchEpochReset(BlockID, BlockID, B256),
     /// [SystemConfig] update failed.
+    ///
+    /// [SystemConfig]: crate::types::SystemConfig
     SystemConfigUpdate,
     /// Broken time invariant between L2 and L1.
     BrokenTimeInvariant(BlockID, u64, BlockID, u64),

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -44,7 +44,7 @@ mod l1_block_info;
 pub use l1_block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};
 
 mod blob;
-pub use blob::{Blob, BlobData, IndexedBlobHash};
+pub use blob::{Blob, BlobData, BlobDecodingError, IndexedBlobHash};
 
 mod genesis;
 pub use genesis::Genesis;


### PR DESCRIPTION
## Overview

Allows the CI to fail on doclint failure, and fixes our existing warnings/errors.