### PR TITLE
chore(workspace): Move `alloy-primitives` to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["**/target", "benches/", "tests"]
 anyhow = { version = "1.0.79", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 cfg-if = "1.0.0"
+alloy-primitives = { version = "0.7.0", default-features = false }
 
 [profile.dev]
 opt-level = 1

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -12,13 +12,13 @@ homepage.workspace = true
 # Workspace
 anyhow.workspace = true
 tracing.workspace = true
+alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # External
-op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
-alloy-primitives = { version = "0.7.0", default-features = false, features = ["rlp"] }
 alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }
 alloy-sol-types = { version = "0.7.0", default-features = false }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
+op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
 async-trait = "0.1.77"
 hashbrown = "0.14.3"

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -13,12 +13,10 @@ homepage.workspace = true
 anyhow.workspace = true
 cfg-if.workspace = true
 tracing.workspace = true
+alloy-primitives.workspace = true
 
 # local
 kona-common = { path = "../common", version = "0.0.1" }
-
-# External
-alloy-primitives = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["full"] }

--- a/examples/simple-revm/Cargo.lock
+++ b/examples/simple-revm/Cargo.lock
@@ -38,6 +38,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bbad0a6b588ef4aec1b5ddbbfdacd9ef04e00b979617765b03174318ee1f3a"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "ruint",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,9 +385,11 @@ dependencies = [
 name = "kona-preimage"
 version = "0.0.1"
 dependencies = [
+ "alloy-primitives 0.7.0",
  "anyhow",
  "cfg-if",
  "kona-common",
+ "tracing",
 ]
 
 [[package]]
@@ -497,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,7 +640,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3683a40f1e94e7389c8e81e5f26bb5d30875ed0b48ab07985ec32eb6d6c712"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.6.2",
  "auto_impl",
  "bitflags",
  "bitvec",
@@ -827,6 +851,22 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "typenum"


### PR DESCRIPTION
## Overview

Moves `alloy-primitives` to the workspace dependencies, as it's used in multiple crates at the moment.