### PR TITLE
chore(workspace): Cleanup justfiles

### DIFF
--- a/build/justfile
+++ b/build/justfile
@@ -1,5 +1,9 @@
 set fallback := true
 
+# default recipe to display help information
+default:
+  @just --list
+
 all: cannon asterisc
 
 # Build the `cannon` program builder image

--- a/fpvm-tests/justfile
+++ b/fpvm-tests/justfile
@@ -1,3 +1,9 @@
+set fallback := true
+
+# default recipe to display help information
+default:
+  @just --list
+
 # Test all FPVM targets
 test: build-cannon-examples build-asterisc-examples test-cannon test-asterisc
 


### PR DESCRIPTION
## Overview

Cleans up the justfiles w/ default directives and fallbacks. Does not touch the justfiles in the example program directories.