### PR TITLE
feat(derive): Payload Attributes Builder Tests

### DIFF
--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -16,7 +16,7 @@ mod deposits;
 pub(crate) use deposits::derive_deposits;
 
 mod builder;
-pub use builder::{AttributesBuilder, StatefulAttributesBuilder};
+pub use builder::{AttributesBuilder, StatefulAttributesBuilder, SystemConfigL2Fetcher};
 
 /// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
 ///

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -34,6 +34,7 @@ pub use batch_queue::{BatchQueue, BatchQueueProvider};
 mod attributes_queue;
 pub use attributes_queue::{
     AttributesBuilder, AttributesProvider, AttributesQueue, StatefulAttributesBuilder,
+    SystemConfigL2Fetcher,
 };
 
 #[cfg(test)]

--- a/crates/derive/src/stages/test_utils/mod.rs
+++ b/crates/derive/src/stages/test_utils/mod.rs
@@ -20,3 +20,6 @@ pub use channel_reader::MockChannelReaderProvider;
 
 mod tracing;
 pub use tracing::{CollectingLayer, TraceStorage};
+
+mod sys_config_fetcher;
+pub use sys_config_fetcher::MockSystemConfigL2Fetcher;

--- a/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
+++ b/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
@@ -1,0 +1,33 @@
+//! Implements a mock [L2SystemConfigFetcher] for testing.
+
+use crate::{stages::attributes_queue::SystemConfigL2Fetcher, types::SystemConfig};
+use alloy_primitives::B256;
+use hashbrown::HashMap;
+
+/// A mock implementation of the [`SystemConfigL2Fetcher`] for testing.
+#[derive(Debug, Default)]
+pub struct MockSystemConfigL2Fetcher {
+    /// A map from [B256] block hash to a [SystemConfig].
+    pub system_configs: HashMap<B256, SystemConfig>,
+}
+
+impl MockSystemConfigL2Fetcher {
+    /// Inserts a new system config into the mock fetcher with the given hash.
+    pub fn insert(&mut self, hash: B256, config: SystemConfig) {
+        self.system_configs.insert(hash, config);
+    }
+
+    /// Clears all system configs from the mock fetcher.
+    pub fn clear(&mut self) {
+        self.system_configs.clear();
+    }
+}
+
+impl SystemConfigL2Fetcher for MockSystemConfigL2Fetcher {
+    fn system_config_by_l2_hash(&self, hash: B256) -> anyhow::Result<SystemConfig> {
+        self.system_configs
+            .get(&hash)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("system config not found"))
+    }
+}

--- a/crates/derive/src/traits/test_utils/data_sources.rs
+++ b/crates/derive/src/traits/test_utils/data_sources.rs
@@ -67,6 +67,16 @@ impl TestChainProvider {
         self.receipts.push((hash, receipts));
     }
 
+    /// Insert a header into the mock chain provider.
+    pub fn insert_header(&mut self, hash: B256, header: Header) {
+        self.headers.push((hash, header));
+    }
+
+    /// Clears headers from the mock chain provider.
+    pub fn clear_headers(&mut self) {
+        self.headers.clear();
+    }
+
     /// Clears blocks from the mock chain provider.
     pub fn clear_blocks(&mut self) {
         self.blocks.clear();
@@ -81,6 +91,7 @@ impl TestChainProvider {
     pub fn clear(&mut self) {
         self.clear_blocks();
         self.clear_receipts();
+        self.clear_headers();
     }
 }
 
@@ -90,7 +101,7 @@ impl ChainProvider for TestChainProvider {
         if let Some((_, header)) = self.headers.iter().find(|(_, b)| b.hash_slow() == hash) {
             Ok(header.clone())
         } else {
-            Err(anyhow::anyhow!("Block not found"))
+            Err(anyhow::anyhow!("Header not found"))
         }
     }
 


### PR DESCRIPTION
**Description**

Adds unit tests to the `PayloadAttributes` builder. As part of this testing, a `MockSystemConfigL2Fetcher` stub is introduced into the stage `test_utils` module.