### PR TITLE
feat(derive): Span Batch Validation

### DIFF
--- a/crates/derive/src/stages/test_utils/tracing.rs
+++ b/crates/derive/src/stages/test_utils/tracing.rs
@@ -24,6 +24,11 @@ impl TraceStorage {
     pub fn lock(&self) -> spin::MutexGuard<'_, Vec<(Level, String)>> {
         self.0.lock()
     }
+
+    /// Returns if the storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.lock().is_empty()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/derive/src/types/batch/mod.rs
+++ b/crates/derive/src/types/batch/mod.rs
@@ -40,19 +40,21 @@ impl BatchWithInclusionBlock {
     /// One or more consecutive l1_blocks should be provided.
     /// In case of only a single L1 block, the decision whether a batch is valid may have to stay
     /// undecided.
-    pub fn check_batch<BF: L2ChainProvider>(
+    pub async fn check_batch<BF: L2ChainProvider>(
         &self,
         cfg: &RollupConfig,
         l1_blocks: &[BlockInfo],
         l2_safe_head: L2BlockInfo,
-        fetcher: &BF,
+        fetcher: &mut BF,
     ) -> BatchValidity {
         match &self.batch {
             Batch::Single(single_batch) => {
                 single_batch.check_batch(cfg, l1_blocks, l2_safe_head, &self.inclusion_block)
             }
             Batch::Span(span_batch) => {
-                span_batch.check_batch(cfg, l1_blocks, l2_safe_head, &self.inclusion_block, fetcher)
+                span_batch
+                    .check_batch(cfg, l1_blocks, l2_safe_head, &self.inclusion_block, fetcher)
+                    .await
             }
         }
     }

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -435,9 +435,10 @@ mod tests {
     use crate::{
         stages::test_utils::{CollectingLayer, TraceStorage},
         traits::test_utils::MockBlockFetcher,
-        types::{BlockID, Genesis, L2ExecutionPayload, L2ExecutionPayloadEnvelope},
+        types::{BlockID, Genesis, L2ExecutionPayload, L2ExecutionPayloadEnvelope, RawTransaction},
     };
-    use alloy_primitives::{b256, B256};
+    use alloy_primitives::{b256, Bytes, B256};
+    use op_alloy_consensus::OpTxType;
     use tracing::Level;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -1035,7 +1036,58 @@ mod tests {
         assert!(logs[0].contains("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid"));
     }
 
-    // TODO: Test continuing with empty batch info log
+    #[tokio::test]
+    async fn test_continuing_with_empty_batch() {
+        let trace_store: TraceStorage = Default::default();
+        let layer = CollectingLayer::new(trace_store.clone());
+        tracing_subscriber::Registry::default().with(layer).init();
+
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 0,
+            delta_time: Some(0),
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_block_hash =
+            b256!("3333333333333333333333333333333333333333000000000000000000000000");
+        let block =
+            BlockInfo { number: 11, timestamp: 10, hash: l1_block_hash, ..Default::default() };
+        let second_block =
+            BlockInfo { number: 12, timestamp: 21, hash: l1_block_hash, ..Default::default() };
+        let l1_blocks = vec![block, second_block];
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 41, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], payloads: vec![] };
+        let first = SpanBatchElement { epoch_num: 10, timestamp: 20, transactions: vec![] };
+        let second = SpanBatchElement { epoch_num: 10, timestamp: 20, transactions: vec![] };
+        let third = SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![] };
+        let batch = SpanBatch {
+            batches: vec![first, second, third],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Accept
+        );
+        let infos = trace_store.get_by_level(Level::INFO);
+        assert_eq!(infos.len(), 1);
+        assert!(infos[0].contains(
+            "continuing with empty batch before late L1 block to preserve L2 time invariant"
+        ));
+    }
 
     #[tokio::test]
     async fn test_check_batch_exceeds_sequencer_time_drift() {
@@ -1100,9 +1152,125 @@ mod tests {
         assert!(logs[0].contains("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again, max_time: 10"));
     }
 
-    // TODO: Test empty transaction
+    #[tokio::test]
+    async fn test_check_batch_empty_txs() {
+        let trace_store: TraceStorage = Default::default();
+        let layer = CollectingLayer::new(trace_store.clone());
+        tracing_subscriber::Registry::default().with(layer).init();
 
-    // TODO: Test deposit transaction embedded into batch data
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            delta_time: Some(0),
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_block_hash =
+            b256!("3333333333333333333333333333333333333333000000000000000000000000");
+        let block =
+            BlockInfo { number: 11, timestamp: 10, hash: l1_block_hash, ..Default::default() };
+        let second_block =
+            BlockInfo { number: 12, timestamp: 21, hash: l1_block_hash, ..Default::default() };
+        let l1_blocks = vec![block, second_block];
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 41, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], payloads: vec![] };
+        let first = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![Default::default()],
+        };
+        let second = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![Default::default()],
+        };
+        let third = SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![] };
+        let batch = SpanBatch {
+            batches: vec![first, second, third],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Drop
+        );
+        let logs = trace_store.get_by_level(Level::WARN);
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("transaction data must not be empty, but found empty tx"));
+    }
+
+    #[tokio::test]
+    async fn test_check_batch_with_deposit_tx() {
+        let trace_store: TraceStorage = Default::default();
+        let layer = CollectingLayer::new(trace_store.clone());
+        tracing_subscriber::Registry::default().with(layer).init();
+
+        let cfg = RollupConfig {
+            seq_window_size: 100,
+            max_sequencer_drift: 100,
+            delta_time: Some(0),
+            block_time: 10,
+            ..Default::default()
+        };
+        let l1_block_hash =
+            b256!("3333333333333333333333333333333333333333000000000000000000000000");
+        let block =
+            BlockInfo { number: 11, timestamp: 10, hash: l1_block_hash, ..Default::default() };
+        let second_block =
+            BlockInfo { number: 12, timestamp: 21, hash: l1_block_hash, ..Default::default() };
+        let l1_blocks = vec![block, second_block];
+        let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 41, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 50, ..Default::default() };
+        let l2_block = L2BlockInfo {
+            block_info: BlockInfo { number: 40, ..Default::default() },
+            ..Default::default()
+        };
+        let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], payloads: vec![] };
+        let filler_bytes = RawTransaction(Bytes::copy_from_slice(&[OpTxType::Eip1559 as u8]));
+        let first = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![filler_bytes.clone()],
+        };
+        let second = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 20,
+            transactions: vec![RawTransaction(Bytes::copy_from_slice(&[OpTxType::Deposit as u8]))],
+        };
+        let third =
+            SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![filler_bytes] };
+        let batch = SpanBatch {
+            batches: vec![first, second, third],
+            parent_check: FixedBytes::<20>::from_slice(&parent_hash[..20]),
+            l1_origin_check: FixedBytes::<20>::from_slice(&l1_block_hash[..20]),
+            txs: SpanBatchTransactions::default(),
+            ..Default::default()
+        };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Drop
+        );
+        let logs = trace_store.get_by_level(Level::WARN);
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("sequencers may not embed any deposits into batch data, but found tx that has one, tx_index: 0"));
+    }
 
     #[tokio::test]
     async fn test_check_batch_failed_to_fetch_payload() {

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -12,6 +12,8 @@ use crate::{
 };
 use alloc::{vec, vec::Vec};
 use alloy_primitives::FixedBytes;
+use op_alloy_consensus::OpTxType;
+use tracing::{info, warn};
 
 /// The span batch contains the input to build a span of L2 blocks in derived form.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -40,16 +42,280 @@ impl SpanBatch {
         self.batches[0].timestamp
     }
 
+    /// Returns the epoch number for the first batch in the span.
+    pub fn starting_epoch_num(&self) -> u64 {
+        self.batches[0].epoch_num
+    }
+
+    /// Checks if the first 20 bytes of the given hash match the L1 origin check.
+    pub fn check_origin_hash(&self, hash: FixedBytes<32>) -> bool {
+        self.l1_origin_check == hash[..20]
+    }
+
+    /// Checks if the first 20 bytes of the given hash match the parent check.
+    pub fn check_parent_hash(&self, hash: FixedBytes<32>) -> bool {
+        self.parent_check == hash[..20]
+    }
+
     /// Checks if the span batch is valid.
-    pub fn check_batch<BF: L2ChainProvider>(
+    pub async fn check_batch<BF: L2ChainProvider>(
         &self,
-        _cfg: &RollupConfig,
-        _l1_blocks: &[BlockInfo],
-        _l2_safe_head: L2BlockInfo,
-        _inclusion_block: &BlockInfo,
-        _fetcher: &BF,
+        cfg: &RollupConfig,
+        l1_blocks: &[BlockInfo],
+        l2_safe_head: L2BlockInfo,
+        inclusion_block: &BlockInfo,
+        fetcher: &mut BF,
     ) -> BatchValidity {
-        unimplemented!()
+        if l1_blocks.is_empty() {
+            warn!("missing L1 block input, cannot proceed with batch checking");
+            return BatchValidity::Undecided;
+        }
+        if self.batches.is_empty() {
+            warn!("empty span batch, cannot proceed with batch checking");
+            return BatchValidity::Undecided;
+        }
+        let epoch = l1_blocks[0];
+        let mut batch_origin = epoch;
+        let starting_epoch_num = self.starting_epoch_num();
+        if starting_epoch_num == batch_origin.number + 1 {
+            if l1_blocks.len() < 2 {
+                info!("eager batch wants to advance current epoch {}, but could not without more L1 blocks", epoch.id());
+                return BatchValidity::Undecided;
+            }
+            batch_origin = l1_blocks[1];
+        }
+
+        // Span batches are only valid after the Delta hard fork.
+        if !cfg.is_delta_active(batch_origin.timestamp) {
+            warn!(
+                "received SpanBatch (id {}) with L1 origin (timestamp {}) before Delta hard fork",
+                batch_origin.id(),
+                batch_origin.timestamp
+            );
+            return BatchValidity::Drop;
+        }
+
+        // Skip out of order batches.
+        let next_timestamp = l2_safe_head.block_info.timestamp + cfg.block_time;
+        if self.timestamp() > next_timestamp {
+            warn!(
+                "received out-of-order batch for future processing after next batch ({} > {})",
+                self.timestamp(),
+                next_timestamp
+            );
+            return BatchValidity::Future;
+        }
+        // SAFETY: The span batch is not empty so the last element exists.
+        if self.batches.last().unwrap().timestamp < next_timestamp {
+            warn!("span batch has no new blocks after safe head");
+            return BatchValidity::Drop;
+        }
+
+        // Find the parent block of the span batch.
+        // If the span batch does not overlap the current safe chain, parent block should be the L2
+        // safe head.
+        let mut parent_num = l2_safe_head.block_info.number;
+        let parent_block = l2_safe_head;
+        if self.timestamp() < next_timestamp {
+            if self.timestamp() > l2_safe_head.block_info.timestamp {
+                // Batch timestamp cannot be between safe head and next timestamp.
+                warn!("batch has misaligned timestamp, block time is too short");
+                return BatchValidity::Drop;
+            }
+            if (l2_safe_head.block_info.timestamp - self.timestamp()) % cfg.block_time != 0 {
+                warn!("batch has misaligned timestamp, not overlapped exactly");
+                return BatchValidity::Drop;
+            }
+            parent_num = l2_safe_head.block_info.number -
+                (l2_safe_head.block_info.timestamp - self.timestamp()) / cfg.block_time -
+                1;
+            let parent_block = match fetcher.l2_block_info_by_number(parent_num).await {
+                Ok(block) => block,
+                Err(e) => {
+                    warn!("failed to fetch L2 block number {parent_num}: {e}");
+                    // Unable to validate the batch for now. Retry later.
+                    return BatchValidity::Undecided;
+                }
+            };
+        }
+        if !self.check_parent_hash(parent_block.block_info.parent_hash) {
+            warn!(
+                "parent block number mismatch, expected: {parent_num}, received: {}",
+                parent_block.block_info.number
+            );
+            return BatchValidity::Drop;
+        }
+
+        // Filter out batches that were included too late.
+        if starting_epoch_num + cfg.seq_window_size < inclusion_block.number {
+            warn!("batch was included too late, sequence window expired");
+            return BatchValidity::Drop;
+        }
+
+        // Check the L1 origin of the batch
+        if starting_epoch_num > parent_block.l1_origin.number + 1 {
+            warn!(
+                "batch is for future epoch too far ahead, while it has the next timestamp, so it must be invalid, current_epoch: {}",
+                epoch.id()
+            );
+            return BatchValidity::Drop;
+        }
+
+        // Verify the l1 origin hash for each l1 block.
+        // SAFETY: The span batch is not empty so the last element exists.
+        let end_epoch_num = self.batches.last().unwrap().epoch_num;
+        let mut origin_checked = false;
+        // l1Blocks is supplied from batch queue and its length is limited to SequencerWindowSize.
+        for l1_block in l1_blocks {
+            if l1_block.number == end_epoch_num {
+                if !self.check_origin_hash(l1_block.hash) {
+                    warn!(
+                        "batch is for different L1 chain, epoch hash does not match, expected: {}",
+                        l1_block.hash
+                    );
+                    return BatchValidity::Drop;
+                }
+                origin_checked = true;
+                break;
+            }
+        }
+        if !origin_checked {
+            info!("need more l1 blocks to check entire origins of span batch");
+            return BatchValidity::Undecided;
+        }
+
+        // Check if the batch is too old.
+        if starting_epoch_num < parent_block.l1_origin.number {
+            warn!("dropped batch, epoch is too old, minimum: {}", parent_block.block_info.id());
+            return BatchValidity::Drop;
+        }
+
+        let mut origin_index = 0;
+        let mut origin_advanced = starting_epoch_num == parent_block.l1_origin.number + 1;
+        for (i, batch) in self.batches.iter().enumerate() {
+            if batch.timestamp <= l2_safe_head.block_info.timestamp {
+                continue;
+            }
+            // Find the L1 origin for the batch.
+            for (j, j_block) in l1_blocks.iter().enumerate().skip(origin_index) {
+                if batch.epoch_num == j_block.number {
+                    origin_index = j;
+                    break;
+                }
+            }
+            let l1_origin = l1_blocks[origin_index];
+            if i > 0 {
+                origin_advanced = false;
+                if batch.epoch_num > self.batches[i - 1].epoch_num {
+                    origin_advanced = true;
+                }
+            }
+            let block_timestamp = batch.timestamp;
+            if block_timestamp < l1_origin.timestamp {
+                warn!(
+                    "block timestamp is less than L1 origin timestamp, l2_timestamp: {}, l1_timestamp: {}, origin: {}",
+                    block_timestamp,
+                    l1_origin.timestamp,
+                    l1_origin.id()
+                );
+                return BatchValidity::Drop;
+            }
+            // Check if we ran out of sequencer time drift
+            if block_timestamp > l1_origin.timestamp + cfg.max_sequencer_drift {
+                if batch.transactions.is_empty() {
+                    // If the sequencer is co-operating by producing an empty batch,
+                    // then allow the batch if it was the right thing to do to maintain the L2 time
+                    // >= L1 time invariant. We only check batches that do not
+                    // advance the epoch, to ensure epoch advancement regardless of time drift is
+                    // allowed.
+                    if !origin_advanced {
+                        if origin_index + 1 >= l1_blocks.len() {
+                            info!("without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid");
+                            return BatchValidity::Undecided;
+                        }
+                        if block_timestamp >= l1_blocks[origin_index + 1].timestamp {
+                            // check if the next L1 origin could have been adopted
+                            info!("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid");
+                            return BatchValidity::Drop;
+                        } else {
+                            info!("continuing with empty batch before late L1 block to preserve L2 time invariant");
+                        }
+                    }
+                } else {
+                    // If the sequencer is ignoring the time drift rule, then drop the batch and
+                    // force an empty batch instead, as the sequencer is not
+                    // allowed to include anything past this point without moving to the next epoch.
+                    warn!(
+                        "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again, max_time: {}",
+                        l1_origin.timestamp + cfg.max_sequencer_drift
+                    );
+                    return BatchValidity::Drop;
+                }
+            }
+
+            // Check that the transactions are not empty and do not contain any deposits.
+            for (tx_index, tx_bytes) in batch.transactions.iter().enumerate() {
+                if tx_bytes.is_empty() {
+                    warn!(
+                        "transaction data must not be empty, but found empty tx, tx_index: {}",
+                        tx_index
+                    );
+                    return BatchValidity::Drop;
+                }
+                if tx_bytes.0[0] == OpTxType::Deposit as u8 {
+                    warn!("sequencers may not embed any deposits into batch data, but found tx that has one, tx_index: {}", tx_index);
+                    return BatchValidity::Drop;
+                }
+            }
+        }
+
+        // Check overlapped blocks
+        if self.timestamp() < next_timestamp {
+            for i in 0..(l2_safe_head.block_info.number - parent_num) {
+                let safe_block_num = parent_num + i + 1;
+                let safe_block_payload = match fetcher.payload_by_number(safe_block_num).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        warn!("failed to fetch payload for block number {safe_block_num}: {e}");
+                        return BatchValidity::Undecided;
+                    }
+                };
+                let safe_block_txs = &safe_block_payload.execution_payload.transactions;
+                let batch_txs = &self.batches[i as usize].transactions;
+                // Execution payload has deposit txs but batch does not.
+                let deposit_count: usize = safe_block_txs
+                    .iter()
+                    .map(|tx| if tx.0[0] == OpTxType::Deposit as u8 { 1 } else { 0 })
+                    .sum();
+                if safe_block_txs.len() - deposit_count != batch_txs.len() {
+                    warn!(
+                        "overlapped block's tx count does not match, safe_block_txs: {}, batch_txs: {}",
+                        safe_block_txs.len(),
+                        batch_txs.len()
+                    );
+                    return BatchValidity::Drop;
+                }
+                for j in 0..batch_txs.len() {
+                    if safe_block_txs[j + deposit_count] != batch_txs[j].0 {
+                        warn!("overlapped block's transaction does not match");
+                        return BatchValidity::Drop;
+                    }
+                }
+                let safe_block_ref = match safe_block_payload.to_l2_block_ref(cfg) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("failed to extract L2BlockRef from execution payload, hash: {}, err: {e}", safe_block_payload.execution_payload.block_hash);
+                        return BatchValidity::Drop;
+                    }
+                };
+                if safe_block_ref.l1_origin.number != self.batches[i as usize].epoch_num {
+                    warn!("overlapped block's L1 origin number does not match");
+                    return BatchValidity::Drop;
+                }
+            }
+        }
+
+        BatchValidity::Accept
     }
 
     /// Converts the span batch to a raw span batch.

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -1160,7 +1160,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_batch_valid_genesis_epoch() {
+    async fn test_check_batch_valid_with_genesis_epoch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
         tracing_subscriber::Registry::default().with(layer).init();

--- a/crates/derive/src/types/batch/span_batch/element.rs
+++ b/crates/derive/src/types/batch/span_batch/element.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 /// A single batch element is similar to the [SingleBatch] type
 /// but does not contain the parent hash and epoch hash since spans
 /// do not contain this data for every block in the span.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SpanBatchElement {
     /// The epoch number of the L1 block
     pub epoch_num: u64,

--- a/crates/derive/src/types/payload.rs
+++ b/crates/derive/src/types/payload.rs
@@ -44,7 +44,7 @@ impl L2ExecutionPayloadEnvelope {
 
 /// The execution payload.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct L2ExecutionPayload {
     /// The parent hash.
     #[cfg_attr(feature = "serde", serde(rename = "parentHash"))]


### PR DESCRIPTION
**Description**

Implements span batch validation.

Unfortunately since the fetcher is colored, we have to mark pure batch derivation methods with `async`.

**Metadata**

Fixes #120 