### PR TITLE
feat(derive): Use `L2ChainProvider` for system config fetching in attributes builder

### DIFF
--- a/crates/derive/src/sources/factory.rs
+++ b/crates/derive/src/sources/factory.rs
@@ -41,7 +41,7 @@ where
             blob_provider: blobs,
             ecotone_timestamp: cfg.ecotone_time,
             plasma_enabled: cfg.is_plasma_enabled(),
-            signer: cfg.l1_signer_address(),
+            signer: cfg.genesis.system_config.batcher_addr,
         }
     }
 }

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -16,7 +16,7 @@ mod deposits;
 pub(crate) use deposits::derive_deposits;
 
 mod builder;
-pub use builder::{AttributesBuilder, StatefulAttributesBuilder, SystemConfigL2Fetcher};
+pub use builder::{AttributesBuilder, StatefulAttributesBuilder};
 
 /// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
 ///

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -34,7 +34,6 @@ pub use batch_queue::{BatchQueue, BatchQueueProvider};
 mod attributes_queue;
 pub use attributes_queue::{
     AttributesBuilder, AttributesProvider, AttributesQueue, StatefulAttributesBuilder,
-    SystemConfigL2Fetcher,
 };
 
 #[cfg(test)]

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -2,9 +2,10 @@
 //! pipeline's stages.
 
 use crate::types::{
-    Blob, BlockInfo, IndexedBlobHash, L2BlockInfo, L2ExecutionPayloadEnvelope, StageResult,
+    Blob, BlockInfo, IndexedBlobHash, L2BlockInfo, L2ExecutionPayloadEnvelope, RollupConfig,
+    StageResult, SystemConfig,
 };
-use alloc::{boxed::Box, fmt::Debug, vec::Vec};
+use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::{Address, Bytes, B256};
 use anyhow::Result;
@@ -41,6 +42,13 @@ pub trait L2ChainProvider {
     /// Returns an execution payload for a given number.
     /// Errors if the execution payload does not exist.
     async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope>;
+
+    /// Returns the [SystemConfig] by L2 number.
+    async fn system_config_by_number(
+        &mut self,
+        number: u64,
+        rollup_config: Arc<RollupConfig>,
+    ) -> Result<SystemConfig>;
 }
 
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.

--- a/crates/derive/src/types/l1_block_info.rs
+++ b/crates/derive/src/types/l1_block_info.rs
@@ -226,8 +226,8 @@ impl L1BlockInfoTx {
     /// Encodes the [L1BlockInfoTx] object into Ethereum transaction calldata.
     pub fn encode_calldata(&self) -> Bytes {
         match self {
-            Self::Ecotone(ecotone_tx) => ecotone_tx.encode_calldata(),
             Self::Bedrock(bedrock_tx) => bedrock_tx.encode_calldata(),
+            Self::Ecotone(ecotone_tx) => ecotone_tx.encode_calldata(),
         }
     }
 
@@ -243,11 +243,27 @@ impl L1BlockInfoTx {
         }
     }
 
+    /// Returns the L1 fee overhead for the info transaction. After ecotone, this value is ignored.
+    pub fn l1_fee_overhead(&self) -> U256 {
+        match self {
+            Self::Bedrock(L1BlockInfoBedrock { l1_fee_overhead, .. }) => *l1_fee_overhead,
+            Self::Ecotone(_) => U256::ZERO,
+        }
+    }
+
+    /// Returns the batcher address for the info transaction
+    pub fn batcher_address(&self) -> Address {
+        match self {
+            Self::Bedrock(L1BlockInfoBedrock { batcher_address, .. }) => *batcher_address,
+            Self::Ecotone(L1BlockInfoEcotone { batcher_address, .. }) => *batcher_address,
+        }
+    }
+
     /// Returns the sequence number for the info transaction
     pub fn sequence_number(&self) -> u64 {
         match self {
-            Self::Ecotone(L1BlockInfoEcotone { sequence_number, .. }) => *sequence_number,
             Self::Bedrock(L1BlockInfoBedrock { sequence_number, .. }) => *sequence_number,
+            Self::Ecotone(L1BlockInfoEcotone { sequence_number, .. }) => *sequence_number,
         }
     }
 }

--- a/crates/derive/src/types/rollup_config.rs
+++ b/crates/derive/src/types/rollup_config.rs
@@ -84,11 +84,6 @@ impl RollupConfig {
         self.regolith_time.map_or(false, |t| timestamp >= t)
     }
 
-    /// Returns the L1 Signer Address.
-    pub fn l1_signer_address(&self) -> Address {
-        self.genesis.system_config.unsafe_block_signer
-    }
-
     /// Returns true if Canyon is active at the given timestamp.
     pub fn is_canyon_active(&self, timestamp: u64) -> bool {
         self.canyon_time.map_or(false, |t| timestamp >= t)

--- a/crates/derive/src/types/system_config.rs
+++ b/crates/derive/src/types/system_config.rs
@@ -22,8 +22,6 @@ pub struct SystemConfig {
     /// Fee scalar
     #[cfg_attr(feature = "serde", serde(rename = "scalar"))]
     pub l1_fee_scalar: U256,
-    /// Sequencer's signer for unsafe blocks
-    pub unsafe_block_signer: Address,
 }
 
 /// Represents type of update to the system config.


### PR DESCRIPTION
## Overview

Reuses the `L2ChainProvider` for fetching the `SystemConfig` at a given block, rather than having an exlusive trait that extends the `L2ChainProvider`.
