### PR TITLE
feat(plasma): Implements Plasma Support for kona-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,7 @@ dependencies = [
  "async-trait",
  "c-kzg",
  "hashbrown",
+ "kona-plasma",
  "kona-primitives",
  "lru",
  "miniz_oxide",
@@ -1493,6 +1494,21 @@ dependencies = [
  "anyhow",
  "reqwest",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "kona-plasma"
+version = "0.0.1"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "anyhow",
+ "async-trait",
+ "kona-primitives",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -17,6 +17,10 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 
 # Local
 kona-primitives = { path = "../primitives", version = "0.0.1" }
+kona-plasma = { path = "../plasma", version = "0.0.1" }
+
+# Local
+kona-primitives = { path = "../primitives", version = "0.0.1" }
 
 # External
 alloy-sol-types = { version = "0.7.1", default-features = false }
@@ -51,7 +55,7 @@ serde_json = { version = "1.0.116", default-features = false }
 
 [features]
 default = ["serde", "k256"]
-serde = ["dep:serde", "alloy-primitives/serde", "alloy-consensus/serde", "op-alloy-consensus/serde"]
+serde = ["dep:serde", "kona-plasma/serde", "alloy-primitives/serde", "alloy-consensus/serde", "op-alloy-consensus/serde"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256", "op-alloy-consensus/k256"]
 online = [
   "dep:revm-primitives",

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -19,9 +19,6 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 kona-primitives = { path = "../primitives", version = "0.0.1" }
 kona-plasma = { path = "../plasma", version = "0.0.1" }
 
-# Local
-kona-primitives = { path = "../primitives", version = "0.0.1" }
-
 # External
 alloy-sol-types = { version = "0.7.1", default-features = false }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -43,6 +43,7 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f
 reqwest = { version = "0.12", default-features = false, optional = true }
 
 [dev-dependencies]
+kona-plasma = { path = "../plasma", version = "0.0.1", features = ["default", "test-utils"] }
 tokio = { version = "1.37", features = ["full"] }
 proptest = "1.4.0"
 tracing-subscriber = "0.3.18"

--- a/crates/derive/src/params.rs
+++ b/crates/derive/src/params.rs
@@ -30,13 +30,6 @@ pub const CHANNEL_ID_LENGTH: usize = 16;
 /// [ChannelID] is an opaque identifier for a channel.
 pub type ChannelID = [u8; CHANNEL_ID_LENGTH];
 
-/// `keccak256("ConfigUpdate(uint256,uint8,bytes)")`
-pub const CONFIG_UPDATE_TOPIC: B256 =
-    b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");
-
-/// The initial version of the system config event log.
-pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
-
 /// Frames cannot be larger than 1MB.
 /// Data transactions that carry frames are generally not larger than 128 KB due to L1 network
 /// conditions, but we leave space to grow larger anyway (gas limit allows for more data).
@@ -44,6 +37,13 @@ pub const MAX_FRAME_LEN: usize = 1000;
 
 /// Deposit log event abi signature.
 pub const DEPOSIT_EVENT_ABI: &str = "TransactionDeposited(address,address,uint256,bytes)";
+
+/// `keccak256("ConfigUpdate(uint256,uint8,bytes)")`
+pub const CONFIG_UPDATE_TOPIC: B256 =
+    b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");
+
+/// The initial version of the system config event log.
+pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
 
 /// Deposit event abi hash.
 ///

--- a/crates/derive/src/sources/factory.rs
+++ b/crates/derive/src/sources/factory.rs
@@ -3,24 +3,34 @@
 use crate::{
     sources::{BlobSource, CalldataSource, DataSource, PlasmaSource},
     traits::{BlobProvider, ChainProvider, DataAvailabilityProvider},
-    types::{BlockInfo, RollupConfig},
+    types::{BlockID, BlockInfo, RollupConfig},
 };
 use alloc::{boxed::Box, fmt::Debug};
 use alloy_primitives::{Address, Bytes};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use kona_plasma::traits::{ChainProvider as PlasmaChainProvider, PlasmaInputFetcher};
 
 /// A factory for creating a calldata and blob provider.
 #[derive(Debug, Clone, Copy)]
-pub struct DataSourceFactory<C, B>
+pub struct DataSourceFactory<C, B, PCP, PIF, I>
 where
     C: ChainProvider + Clone,
     B: BlobProvider + Clone,
+    PCP: PlasmaChainProvider + Send + Clone,
+    PIF: PlasmaInputFetcher<PCP> + Clone,
+    I: Iterator<Item = Bytes> + Send + Clone,
 {
     /// The chain provider to use for the factory.
     pub chain_provider: C,
+    /// The plasma chain provider.
+    pub plasma_chain_provider: PCP,
+    /// The plasma iterator.
+    pub plasma_source: I,
     /// The blob provider
     pub blob_provider: B,
+    /// The plasma input fetcher.
+    pub plasma_input_fetcher: PIF,
     /// The ecotone timestamp.
     pub ecotone_timestamp: Option<u64>,
     /// Whether or not plasma is enabled.
@@ -29,16 +39,22 @@ where
     pub signer: Address,
 }
 
-impl<C, B> DataSourceFactory<C, B>
+impl<C, B, PCP, PIF, I> DataSourceFactory<C, B, PCP, PIF, I>
 where
     C: ChainProvider + Clone + Debug,
     B: BlobProvider + Clone + Debug,
+    PCP: PlasmaChainProvider + Send + Clone + Debug,
+    PIF: PlasmaInputFetcher<PCP> + Clone + Debug,
+    I: Iterator<Item = Bytes> + Send + Clone,
 {
     /// Creates a new factory.
-    pub fn new(provider: C, blobs: B, cfg: &RollupConfig) -> Self {
+    pub fn new(provider: C, blobs: B, pcp: PCP, pif: PIF, s: I, cfg: &RollupConfig) -> Self {
         Self {
             chain_provider: provider,
+            plasma_chain_provider: pcp,
+            plasma_source: s,
             blob_provider: blobs,
+            plasma_input_fetcher: pif,
             ecotone_timestamp: cfg.ecotone_time,
             plasma_enabled: cfg.is_plasma_enabled(),
             signer: cfg.genesis.system_config.batcher_addr,
@@ -47,13 +63,16 @@ where
 }
 
 #[async_trait]
-impl<C, B> DataAvailabilityProvider for DataSourceFactory<C, B>
+impl<C, B, PCP, PIF, I> DataAvailabilityProvider for DataSourceFactory<C, B, PCP, PIF, I>
 where
     C: ChainProvider + Send + Sync + Clone + Debug,
     B: BlobProvider + Send + Sync + Clone + Debug,
+    PCP: PlasmaChainProvider + Send + Sync + Clone + Debug,
+    PIF: PlasmaInputFetcher<PCP> + Send + Sync + Clone + Debug,
+    I: Iterator<Item = Bytes> + Send + Sync + Clone + Debug,
 {
     type Item = Bytes;
-    type DataIter = DataSource<C, B>;
+    type DataIter = DataSource<C, B, PCP, PIF, I>;
 
     async fn open_data(
         &self,
@@ -81,7 +100,13 @@ where
                 });
             Ok(source)
         } else if self.plasma_enabled {
-            Ok(DataSource::Plasma(PlasmaSource::new(self.chain_provider.clone())))
+            let id = BlockID { hash: block_ref.hash, number: block_ref.number };
+            Ok(DataSource::Plasma(PlasmaSource::new(
+                self.plasma_chain_provider.clone(),
+                self.plasma_input_fetcher.clone(),
+                self.plasma_source.clone(),
+                id,
+            )))
         } else {
             Err(anyhow!("No data source available"))
         }

--- a/crates/derive/src/sources/plasma.rs
+++ b/crates/derive/src/sources/plasma.rs
@@ -1,42 +1,177 @@
 //! Plasma Data Source
 
 use crate::{
-    traits::{AsyncIterator, ChainProvider},
-    types::StageResult,
+    traits::AsyncIterator,
+    types::{ResetError, StageError, StageResult},
 };
 use alloc::boxed::Box;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
+use kona_plasma::{
+    traits::{ChainProvider, PlasmaInputFetcher},
+    types::{
+        decode_keccak256, Keccak256Commitment, PlasmaError, MAX_INPUT_SIZE, TX_DATA_VERSION_1,
+    },
+};
+use kona_primitives::block::BlockID;
 
 /// A plasma data iterator.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct PlasmaSource<CP>
+pub struct PlasmaSource<CP, PIF, I>
 where
     CP: ChainProvider + Send,
+    PIF: PlasmaInputFetcher<CP> + Send,
+    I: Iterator<Item = Bytes>,
 {
+    /// The plasma input fetcher.
+    input_fetcher: PIF,
     /// The chain provider to use for the plasma source.
     chain_provider: CP,
-    /// The plasma commitment.
-    commitment: Bytes,
-    /// The block number.
-    block_number: u64,
-    /// Whether the plasma source is open.
-    open: bool,
+    /// A source data iterator.
+    source: I,
+    /// Keeps track of a pending commitment so we can keep trying to fetch the input.
+    commitment: Option<Keccak256Commitment>,
+    /// The block Id.
+    id: BlockID,
 }
 
-impl<CP: ChainProvider + Send> PlasmaSource<CP> {
+impl<CP, PIF, I> PlasmaSource<CP, PIF, I>
+where
+    CP: ChainProvider + Send,
+    PIF: PlasmaInputFetcher<CP> + Send,
+    I: Iterator<Item = Bytes>,
+{
     /// Instantiates a new plasma data source.
-    pub fn new(chain_provider: CP) -> Self {
-        Self { chain_provider, commitment: Bytes::default(), block_number: 0, open: false }
+    pub fn new(chain_provider: CP, input_fetcher: PIF, source: I, id: BlockID) -> Self {
+        Self { chain_provider, input_fetcher, source, id, commitment: None }
     }
 }
 
 #[async_trait]
-impl<CP: ChainProvider + Send> AsyncIterator for PlasmaSource<CP> {
+impl<CP, PIF, I> AsyncIterator for PlasmaSource<CP, PIF, I>
+where
+    CP: ChainProvider + Send,
+    PIF: PlasmaInputFetcher<CP> + Send,
+    I: Iterator<Item = Bytes> + Send,
+{
     type Item = Bytes;
 
     async fn next(&mut self) -> Option<StageResult<Self::Item>> {
-        unimplemented!("Plasma will not be supported until further notice.");
+        // Process origin syncs the challenge contract events and updates the local challenge states
+        // before we can proceed to fetch the input data. This function can be called multiple times
+        // for the same origin and noop if the origin was already processed. It is also called if
+        // there is not commitment in the current origin.
+        match self.input_fetcher.advance_l1_origin(&self.chain_provider, self.id).await {
+            Some(Ok(_)) => (),
+            Some(Err(PlasmaError::ReorgRequired)) => {
+                tracing::error!("new expired challenge");
+                return Some(StageResult::Err(StageError::Custom(anyhow::anyhow!(
+                    "new expired challenge"
+                ))));
+            }
+            Some(Err(e)) => {
+                tracing::error!("failed to advance plasma L1 origin: {:?}", e);
+                return Some(StageResult::Err(StageError::Plasma(e)));
+            }
+            None => {
+                tracing::warn!("l1 origin advance returned None");
+            }
+        }
+
+        // Set the commitment if it isn't available.
+        if self.commitment.is_none() {
+            // The l1 source returns the input commitment for the batch.
+            let data = match self.source.next().ok_or(PlasmaError::NotEnoughData) {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!("failed to pull next data from the plasma source iterator");
+                    return Some(Err(StageError::Plasma(e)));
+                }
+            };
+
+            // If the data is empty,
+            if data.is_empty() {
+                return Some(Err(StageError::Plasma(PlasmaError::NotEnoughData)));
+            }
+
+            // If the tx data type is not plasma, we forward it downstream to let the next
+            // steps validate and potentially parse it as L1 DA inputs.
+            if data[0] != TX_DATA_VERSION_1 {
+                return Some(Ok(data));
+            }
+
+            // Validate that the batcher inbox data is a commitment.
+            self.commitment = match decode_keccak256(&data[1..]) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    tracing::warn!("invalid commitment: {}, err: {}", data, e);
+                    return self.next().await;
+                }
+            };
+        }
+
+        // Use the commitment to fetch the input from the plasma DA provider.
+        let commitment = self.commitment.as_ref().expect("the commitment must be set");
+
+        // Fetch the input data from the plasma DA provider.
+        let data = match self
+            .input_fetcher
+            .get_input(&self.chain_provider, commitment.clone(), self.id)
+            .await
+        {
+            Some(Ok(data)) => data,
+            Some(Err(PlasmaError::ReorgRequired)) => {
+                // The plasma fetcher may call for a reorg if the pipeline is stalled and the plasma
+                // DA manager continued syncing origins detached from the pipeline
+                // origin.
+                tracing::warn!("challenge for a new previously derived commitment expired");
+                return Some(Err(StageError::Reset(ResetError::ReorgRequired)));
+            }
+            Some(Err(PlasmaError::ChallengeExpired)) => {
+                // This commitment was challenged and the challenge expired.
+                tracing::warn!("challenge expired, skipping batch");
+                self.commitment = None;
+                // Skip the input.
+                return self.next().await
+            }
+            Some(Err(PlasmaError::MissingPastWindow)) => {
+                return Some(Err(StageError::Custom(anyhow::anyhow!(
+                    "data for comm {:?} not available",
+                    commitment
+                ))));
+            }
+            Some(Err(PlasmaError::ChallengePending)) => {
+                // Continue stepping without slowing down.
+                return Some(Err(StageError::NotEnoughData));
+            }
+            Some(Err(e)) => {
+                // Return temporary error so we can keep retrying.
+                return Some(Err(StageError::Custom(anyhow::anyhow!(
+                    "failed to fetch input data with comm {:?} from da service: {:?}",
+                    commitment,
+                    e
+                ))));
+            }
+            None => {
+                // Return temporary error so we can keep retrying.
+                return Some(Err(StageError::Custom(anyhow::anyhow!(
+                    "failed to fetch input data with comm {:?} from da service",
+                    commitment
+                ))));
+            }
+        };
+
+        // The data length is limited to a max size to ensure they can be challenged in the DA
+        // contract.
+        if data.len() > MAX_INPUT_SIZE {
+            tracing::warn!("input data (len {}) exceeds max size {MAX_INPUT_SIZE}", data.len());
+            self.commitment = None;
+            return self.next().await;
+        }
+
+        // Reset the commitment so we can fetch the next one from the source at the next iteration.
+        self.commitment = None;
+
+        return Some(Ok(data));
     }
 }

--- a/crates/derive/src/sources/plasma.rs
+++ b/crates/derive/src/sources/plasma.rs
@@ -135,18 +135,20 @@ where
                 return self.next().await
             }
             Some(Err(PlasmaError::MissingPastWindow)) => {
-                return Some(Err(StageError::Custom(anyhow::anyhow!(
-                    "data for comm {:?} not available",
+                tracing::warn!("missing past window, skipping batch");
+                return Some(Err(StageError::Critical(anyhow::anyhow!(
+                    "data for commitment {:?} not available",
                     commitment
                 ))));
             }
             Some(Err(PlasmaError::ChallengePending)) => {
                 // Continue stepping without slowing down.
+                tracing::debug!("plasma challenge pending, proceeding");
                 return Some(Err(StageError::NotEnoughData));
             }
             Some(Err(e)) => {
                 // Return temporary error so we can keep retrying.
-                return Some(Err(StageError::Custom(anyhow::anyhow!(
+                return Some(Err(StageError::Temporary(anyhow::anyhow!(
                     "failed to fetch input data with comm {:?} from da service: {:?}",
                     commitment,
                     e
@@ -154,7 +156,7 @@ where
             }
             None => {
                 // Return temporary error so we can keep retrying.
-                return Some(Err(StageError::Custom(anyhow::anyhow!(
+                return Some(Err(StageError::Temporary(anyhow::anyhow!(
                     "failed to fetch input data with comm {:?} from da service",
                     commitment
                 ))));

--- a/crates/derive/src/sources/source.rs
+++ b/crates/derive/src/sources/source.rs
@@ -8,27 +8,34 @@ use crate::{
 use alloc::boxed::Box;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
+use kona_plasma::traits::{ChainProvider as PlasmaChainProvider, PlasmaInputFetcher};
 
 /// An enum over the various data sources.
 #[derive(Debug, Clone)]
-pub enum DataSource<CP, B>
+pub enum DataSource<CP, B, PCP, PIF, I>
 where
     CP: ChainProvider + Send,
     B: BlobProvider + Send,
+    PCP: PlasmaChainProvider + Send,
+    PIF: PlasmaInputFetcher<PCP> + Send,
+    I: Iterator<Item = Bytes> + Send,
 {
     /// A calldata source.
     Calldata(CalldataSource<CP>),
     /// A blob source.
     Blob(BlobSource<CP, B>),
     /// A plasma source.
-    Plasma(PlasmaSource<CP>),
+    Plasma(PlasmaSource<PCP, PIF, I>),
 }
 
 #[async_trait]
-impl<CP, B> AsyncIterator for DataSource<CP, B>
+impl<CP, B, PCP, PIF, I> AsyncIterator for DataSource<CP, B, PCP, PIF, I>
 where
     CP: ChainProvider + Send,
     B: BlobProvider + Send,
+    PCP: PlasmaChainProvider + Send,
+    PIF: PlasmaInputFetcher<PCP> + Send,
+    I: Iterator<Item = Bytes> + Send,
 {
     type Item = Bytes;
 

--- a/crates/derive/src/types/errors.rs
+++ b/crates/derive/src/types/errors.rs
@@ -141,6 +141,8 @@ pub enum ResetError {
     BadTimestamp(u64, u64),
     /// A reorg is required.
     ReorgRequired,
+    /// A new expired challenge.
+    NewExpiredChallenge,
 }
 
 impl PartialEq<ResetError> for ResetError {
@@ -153,6 +155,7 @@ impl PartialEq<ResetError> for ResetError {
                 e1 == e2 && a1 == a2
             }
             (ResetError::ReorgRequired, ResetError::ReorgRequired) => true,
+            (ResetError::NewExpiredChallenge, ResetError::NewExpiredChallenge) => true,
             _ => false,
         }
     }
@@ -168,6 +171,7 @@ impl Display for ResetError {
                 write!(f, "Bad timestamp: expected {}, got {}", expected, actual)
             }
             ResetError::ReorgRequired => write!(f, "Reorg required"),
+            ResetError::NewExpiredChallenge => write!(f, "New expired challenge"),
         }
     }
 }

--- a/crates/plasma/Cargo.toml
+++ b/crates/plasma/Cargo.toml
@@ -31,3 +31,4 @@ serde_json = { version = "1.0.68", default-features = false }
 [features]
 default = ["serde"]
 serde = ["dep:serde"]
+test-utils = []

--- a/crates/plasma/Cargo.toml
+++ b/crates/plasma/Cargo.toml
@@ -14,7 +14,7 @@ anyhow.workspace = true
 tracing.workspace = true
 
 # Local
-kona-primitives = { path = "../primitives", verison = "0.0.1" }
+kona-primitives = { path = "../primitives" }
 
 # External
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }

--- a/crates/plasma/Cargo.toml
+++ b/crates/plasma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "kona-primitives"
-description = "Primitive types for kona crates"
+name = "kona-plasma"
+description = "Plasma Data Availability Adapter"
 version = "0.0.1"
 edition.workspace = true
 authors.workspace = true
@@ -9,18 +9,23 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+# Workspace
 anyhow.workspace = true
-# Alloy Types
-alloy-sol-types = { version = "0.7.1", default-features = false }
-alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }
-alloy-primitives = { workspace = true, features = ["rlp"] }
+tracing.workspace = true
+
+# Local
+kona-primitives = { path = "../primitives", verison = "0.0.1" }
+
+# External
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
-op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
+alloy-primitives = { workspace = true, features = ["rlp"] }
+async-trait = "0.1.77"
 
 # `serde` feature dependencies
 serde = { version = "1.0.197", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
+tracing-subscriber = "0.3.18"
 serde_json = { version = "1.0.68", default-features = false }
 
 [features]

--- a/crates/plasma/README.md
+++ b/crates/plasma/README.md
@@ -1,0 +1,27 @@
+# `kona-plasma`
+
+Plasma Data Availability Adapter for `kona-derive`.
+
+[plasma]: https://specs.optimism.io/experimental/plasma.html
+
+`kona-plasma` is an implementation of the [Plasma][plasma] OP Stack Specification in rust.
+
+## Usage
+
+Add `kona-plasma` to your `Cargo.toml`.
+
+```ignore
+[dependencies]
+kona-plasma = "0.0.1"
+
+# Serde is enabled by default and can be disabled by toggling default-features off
+# kona-plasma = { version = "0.0.1", default-features = false }
+```
+
+## Features
+
+### Serde
+
+[`serde`] serialization and deserialization support for `kona-plasma` types.
+
+By default, the `serde` feature is enabled on `kona-plasma`.

--- a/crates/plasma/src/lib.rs
+++ b/crates/plasma/src/lib.rs
@@ -1,0 +1,21 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_debug_implementations, missing_docs, unreachable_pub, rustdoc::all)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+extern crate alloc;
+
+pub mod traits;
+pub mod types;
+
+// Re-export kona primitives.
+pub use kona_primitives::prelude::*;
+
+/// The prelude exports common types and traits.
+pub mod prelude {
+    pub use crate::{
+        traits::{ChainProvider, PlasmaInputFetcher},
+        types::{FinalizedHeadSignal, Keccak256Commitment, PlasmaError, SystemConfig},
+    };
+}

--- a/crates/plasma/src/lib.rs
+++ b/crates/plasma/src/lib.rs
@@ -19,3 +19,6 @@ pub mod prelude {
         types::{FinalizedHeadSignal, Keccak256Commitment, PlasmaError, SystemConfig},
     };
 }
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;

--- a/crates/plasma/src/test_utils.rs
+++ b/crates/plasma/src/test_utils.rs
@@ -1,0 +1,150 @@
+//! Test utilities for the Plasma crate.
+
+use crate::{
+    traits::{ChainProvider, PlasmaInputFetcher},
+    types::{FinalizedHeadSignal, PlasmaError},
+};
+use alloc::{boxed::Box, vec::Vec};
+use alloy_consensus::{Header, Receipt, TxEnvelope};
+use alloy_primitives::{Bytes, B256};
+use anyhow::Result;
+use async_trait::async_trait;
+use kona_primitives::{
+    block::{BlockID, BlockInfo},
+    system_config::SystemConfig,
+};
+
+/// A mock plasma input fetcher for testing.
+#[derive(Debug, Clone, Default)]
+pub struct TestPlasmaInputFetcher {
+    /// Inputs to return.
+    pub inputs: Vec<Result<Bytes, PlasmaError>>,
+    /// Advance L1 origin results.
+    pub advances: Vec<Result<(), PlasmaError>>,
+    /// Reset results.
+    pub resets: Vec<Result<(), PlasmaError>>,
+}
+
+#[async_trait]
+impl PlasmaInputFetcher<TestChainProvider> for TestPlasmaInputFetcher {
+    async fn get_input(
+        &mut self,
+        _fetcher: &TestChainProvider,
+        _commitment: Bytes,
+        _block: BlockID,
+    ) -> Option<Result<Bytes, PlasmaError>> {
+        self.inputs.pop()
+    }
+
+    async fn advance_l1_origin(
+        &mut self,
+        _fetcher: &TestChainProvider,
+        _block: BlockID,
+    ) -> Option<Result<(), PlasmaError>> {
+        self.advances.pop()
+    }
+
+    async fn reset(
+        &mut self,
+        _block_number: BlockInfo,
+        _cfg: SystemConfig,
+    ) -> Option<Result<(), PlasmaError>> {
+        self.resets.pop()
+    }
+
+    async fn finalize(&mut self, _block_number: BlockInfo) -> Option<Result<(), PlasmaError>> {
+        None
+    }
+
+    fn on_finalized_head_signal(&mut self, _block_number: FinalizedHeadSignal) {}
+}
+
+/// A mock chain provider for testing.
+#[derive(Debug, Clone, Default)]
+pub struct TestChainProvider {
+    /// Maps block numbers to block information using a tuple list.
+    pub blocks: Vec<(u64, BlockInfo)>,
+    /// Maps block hashes to header information using a tuple list.
+    pub headers: Vec<(B256, Header)>,
+    /// Maps block hashes to receipts using a tuple list.
+    pub receipts: Vec<(B256, Vec<Receipt>)>,
+}
+
+impl TestChainProvider {
+    /// Insert a block into the mock chain provider.
+    pub fn insert_block(&mut self, number: u64, block: BlockInfo) {
+        self.blocks.push((number, block));
+    }
+
+    /// Insert receipts into the mock chain provider.
+    pub fn insert_receipts(&mut self, hash: B256, receipts: Vec<Receipt>) {
+        self.receipts.push((hash, receipts));
+    }
+
+    /// Insert a header into the mock chain provider.
+    pub fn insert_header(&mut self, hash: B256, header: Header) {
+        self.headers.push((hash, header));
+    }
+
+    /// Clears headers from the mock chain provider.
+    pub fn clear_headers(&mut self) {
+        self.headers.clear();
+    }
+
+    /// Clears blocks from the mock chain provider.
+    pub fn clear_blocks(&mut self) {
+        self.blocks.clear();
+    }
+
+    /// Clears receipts from the mock chain provider.
+    pub fn clear_receipts(&mut self) {
+        self.receipts.clear();
+    }
+
+    /// Clears all blocks and receipts from the mock chain provider.
+    pub fn clear(&mut self) {
+        self.clear_blocks();
+        self.clear_receipts();
+        self.clear_headers();
+    }
+}
+
+#[async_trait]
+impl ChainProvider for TestChainProvider {
+    async fn header_by_hash(&mut self, hash: B256) -> Result<Header> {
+        if let Some((_, header)) = self.headers.iter().find(|(_, b)| b.hash_slow() == hash) {
+            Ok(header.clone())
+        } else {
+            Err(anyhow::anyhow!("Header not found"))
+        }
+    }
+
+    async fn block_info_by_number(&mut self, _number: u64) -> Result<BlockInfo> {
+        if let Some((_, block)) = self.blocks.iter().find(|(n, _)| *n == _number) {
+            Ok(*block)
+        } else {
+            Err(anyhow::anyhow!("Block not found"))
+        }
+    }
+
+    async fn receipts_by_hash(&mut self, _hash: B256) -> Result<Vec<Receipt>> {
+        if let Some((_, receipts)) = self.receipts.iter().find(|(h, _)| *h == _hash) {
+            Ok(receipts.clone())
+        } else {
+            Err(anyhow::anyhow!("Receipts not found"))
+        }
+    }
+
+    async fn block_info_and_transactions_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>)> {
+        let block = self
+            .blocks
+            .iter()
+            .find(|(_, b)| b.hash == hash)
+            .map(|(_, b)| *b)
+            .ok_or_else(|| anyhow::anyhow!("Block not found"))?;
+        Ok((block, Vec::new()))
+    }
+}

--- a/crates/plasma/src/traits.rs
+++ b/crates/plasma/src/traits.rs
@@ -1,0 +1,65 @@
+//! Traits for plasma sources and internal components.
+
+use crate::types::{FinalizedHeadSignal, PlasmaError};
+use alloc::{boxed::Box, vec::Vec};
+use alloy_consensus::{Header, Receipt, TxEnvelope};
+use alloy_primitives::{Bytes, B256};
+use async_trait::async_trait;
+use kona_primitives::{
+    block::{BlockID, BlockInfo},
+    system_config::SystemConfig,
+};
+
+/// Describes the functionality of a data source that can provide information from the blockchain.
+#[async_trait]
+pub trait ChainProvider {
+    /// Fetch the L1 [Header] for the given [B256] hash.
+    async fn header_by_hash(&mut self, hash: B256) -> anyhow::Result<Header>;
+
+    /// Returns the block at the given number, or an error if the block does not exist in the data
+    /// source.
+    async fn block_info_by_number(&mut self, number: u64) -> anyhow::Result<BlockInfo>;
+
+    /// Returns all receipts in the block with the given hash, or an error if the block does not
+    /// exist in the data source.
+    async fn receipts_by_hash(&mut self, hash: B256) -> anyhow::Result<Vec<Receipt>>;
+
+    /// Returns the [BlockInfo] and list of [TxEnvelope]s from the given block hash.
+    async fn block_info_and_transactions_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> anyhow::Result<(BlockInfo, Vec<TxEnvelope>)>;
+}
+
+/// A plasma input fetcher.
+#[async_trait]
+pub trait PlasmaInputFetcher<CP: ChainProvider + Send> {
+    /// Get the input for the given commitment at the given block number from the DA storage
+    /// service.
+    async fn get_input(
+        &mut self,
+        fetcher: &CP,
+        commitment: Bytes,
+        block: BlockID,
+    ) -> Option<Result<Bytes, PlasmaError>>;
+
+    /// Advance the L1 origin to the given block number, syncing the DA challenge events.
+    async fn advance_l1_origin(
+        &mut self,
+        fetcher: &CP,
+        block: BlockID,
+    ) -> Option<Result<(), PlasmaError>>;
+
+    /// Reset the challenge origin in case of L1 reorg.
+    async fn reset(
+        &mut self,
+        block_number: BlockInfo,
+        cfg: SystemConfig,
+    ) -> Option<Result<(), PlasmaError>>;
+
+    /// Notify L1 finalized head so plasma finality is always behind L1.
+    async fn finalize(&mut self, block_number: BlockInfo) -> Option<Result<(), PlasmaError>>;
+
+    /// Set the engine finalization signal callback.
+    fn on_finalized_head_signal(&mut self, callback: FinalizedHeadSignal);
+}

--- a/crates/plasma/src/types.rs
+++ b/crates/plasma/src/types.rs
@@ -1,0 +1,84 @@
+//! Types for the Kona Plasma crate.
+
+use alloc::boxed::Box;
+use alloy_primitives::{Address, Bytes, U256};
+use core::fmt::Display;
+use kona_primitives::block::BlockInfo;
+
+/// A plasma error.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PlasmaError {
+    /// A reorg is required.
+    ReorgRequired,
+    /// Not enough data.
+    NotEnoughData,
+    /// The commitment was challenge, but the challenge period expired.
+    ChallengeExpired,
+    /// Missing data past the challenge period.
+    MissingPastWindow,
+    /// A challenge is pending for the given commitment
+    ChallengePending,
+}
+
+impl Display for PlasmaError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ReorgRequired => write!(f, "reorg required"),
+            Self::NotEnoughData => write!(f, "not enough data"),
+            Self::ChallengeExpired => write!(f, "challenge expired"),
+            Self::MissingPastWindow => write!(f, "missing past window"),
+            Self::ChallengePending => write!(f, "challenge pending"),
+        }
+    }
+}
+
+/// Max input size ensures the canonical chain cannot include input batches too large to
+/// challenge in the Data Availability Challenge contract. Value in number of bytes.
+/// This value can only be changed in a hard fork.
+pub const MAX_INPUT_SIZE: usize = 130672;
+
+/// TxDataVersion1 is the version number for batcher transactions containing
+/// plasma commitments. It should not collide with DerivationVersion which is still
+/// used downstream when parsing the frames.
+pub const TX_DATA_VERSION_1: u8 = 1;
+
+/// The default commitment type.
+pub type Keccak256Commitment = Bytes;
+
+/// The default commitment type for the DA storage.
+pub const KECCAK_256_COMMITMENT_TYPE: u8 = 0;
+
+/// DecodeKeccak256 validates and casts the commitment into a Keccak256Commitment.
+pub fn decode_keccak256(commitment: &[u8]) -> Result<Keccak256Commitment, PlasmaError> {
+    if commitment.is_empty() {
+        return Err(PlasmaError::NotEnoughData);
+    }
+    if commitment[0] != KECCAK_256_COMMITMENT_TYPE {
+        return Err(PlasmaError::NotEnoughData);
+    }
+    let c = &commitment[1..];
+    if c.len() != 32 {
+        return Err(PlasmaError::NotEnoughData);
+    }
+    Ok(Bytes::copy_from_slice(c))
+}
+
+/// A callback method for the finalized head signal.
+pub type FinalizedHeadSignal = Box<dyn Fn(BlockInfo) + Send>;
+
+/// Optimism system config contract values
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SystemConfig {
+    /// Batch sender address
+    pub batcher_addr: Address,
+    /// L2 gas limit
+    pub gas_limit: U256,
+    /// Fee overhead
+    #[cfg_attr(feature = "serde", serde(rename = "overhead"))]
+    pub l1_fee_overhead: U256,
+    /// Fee scalar
+    #[cfg_attr(feature = "serde", serde(rename = "scalar"))]
+    pub l1_fee_scalar: U256,
+}

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,11 +10,11 @@ homepage.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # Alloy Types
 alloy-sol-types = { version = "0.7.1", default-features = false }
-alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }
-alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "e3f2f07", default-features = false }
 op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+
 # Alloy Types
 alloy-sol-types = { version = "0.7.1", default-features = false }
 alloy-rlp = { version = "0.3.4", default-features = false, features = ["derive"] }


### PR DESCRIPTION
**Description**

Implements the `PlasmaSource` data source in `kona-derive`.

Refactors some `kona-derive` types into a new `kona-primitives` crate.

Also introduces a `kona-plasma` crate to hold `op-plasma` specific types. This module can be built out further to be a feature-complete alternative for `op-plasma`.

**Metadata**

Fixes #119