### PR TITLE
fix(derive): Small Fixes and Span Batch Validation Fix

### DIFF
--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -13,7 +13,6 @@ use tracing::warn;
 
 /// A data iterator that reads from a blob.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct BlobSource<F, B>
 where
     F: ChainProvider + Send,

--- a/crates/derive/src/sources/calldata.rs
+++ b/crates/derive/src/sources/calldata.rs
@@ -11,7 +11,6 @@ use async_trait::async_trait;
 
 /// A data iterator that reads from calldata.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct CalldataSource<CP>
 where
     CP: ChainProvider + Send,

--- a/crates/derive/src/types/batch/mod.rs
+++ b/crates/derive/src/types/batch/mod.rs
@@ -62,7 +62,6 @@ impl BatchWithInclusionBlock {
 
 /// A Batch.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::large_enum_variant)]
 pub enum Batch {
     /// A single batch
     Single(SingleBatch),

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -730,10 +730,12 @@ mod tests {
         };
         let inclusion_block = BlockInfo::default();
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 41, timestamp: 10, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
+        fetcher.short_circuit = true;
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
         let batch = SpanBatch {
@@ -769,7 +771,7 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, parent_hash, timestamp: 10, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -812,7 +814,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, parent_hash, timestamp: 10, ..Default::default() },
+            l1_origin: BlockID { number: 8, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -862,7 +865,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -911,7 +915,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -957,7 +962,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 14, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -977,7 +983,7 @@ mod tests {
         assert_eq!(logs.len(), 1);
         let str = alloc::format!(
             "dropped batch, epoch is too old, minimum: {}",
-            l2_safe_head.block_info.id(),
+            l2_block.block_info.id(),
         );
         assert!(logs[0].contains(&str));
     }
@@ -1297,7 +1303,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let mut fetcher = MockBlockFetcher { blocks: vec![l2_block], ..Default::default() };
@@ -1347,7 +1354,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, timestamp: 10, parent_hash, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let payload = L2ExecutionPayloadEnvelope {
@@ -1411,7 +1419,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, parent_hash, timestamp: 10, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let payload = L2ExecutionPayloadEnvelope {
@@ -1476,7 +1485,8 @@ mod tests {
         };
         let inclusion_block = BlockInfo { number: 50, ..Default::default() };
         let l2_block = L2BlockInfo {
-            block_info: BlockInfo { number: 40, ..Default::default() },
+            block_info: BlockInfo { number: 40, parent_hash, timestamp: 10, ..Default::default() },
+            l1_origin: BlockID { number: 9, ..Default::default() },
             ..Default::default()
         };
         let payload = L2ExecutionPayloadEnvelope {

--- a/crates/derive/src/types/batch/span_batch/batch.rs
+++ b/crates/derive/src/types/batch/span_batch/batch.rs
@@ -8,7 +8,6 @@ use crate::{
         SpanBatchBits, SpanBatchElement, SpanBatchPayload, SpanBatchPrefix,
     },
 };
-
 use alloc::vec::Vec;
 use alloy_primitives::FixedBytes;
 use op_alloy_consensus::OpTxType;

--- a/crates/derive/src/types/ecotone.rs
+++ b/crates/derive/src/types/ecotone.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! Module containing a [Transaction] builder for the Ecotone network updgrade transactions.
 //!
 //! [Transaction]: alloy_consensus::Transaction


### PR DESCRIPTION
**Description**

Removes some erroneous `#[allow(dead_code)]` declarations across the `kona-derive` crate and fixes span batch validation to set the parent block number. It previously fallibly shadowed the `parent_num` variable in a lower block.