### PR TITLE
fix(derive): Ethereum Data Source

### DIFF
--- a/crates/derive/src/sources/ethereum.rs
+++ b/crates/derive/src/sources/ethereum.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloc::{boxed::Box, fmt::Debug};
 use alloy_primitives::{Address, Bytes};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 
 /// A factory for creating an Ethereum data source provider.
@@ -19,9 +19,9 @@ where
     B: BlobProvider + Clone,
 {
     /// The chain provider to use for the factory.
-    pub chain_provider: Option<C>,
+    pub chain_provider: C,
     /// The blob provider
-    pub blob_provider: Option<B>,
+    pub blob_provider: B,
     /// The ecotone timestamp.
     pub ecotone_timestamp: Option<u64>,
     /// The L1 Signer.
@@ -34,7 +34,7 @@ where
     B: BlobProvider + Clone + Debug,
 {
     /// Creates a new factory.
-    pub fn new(provider: Option<C>, blobs: Option<B>, cfg: &RollupConfig) -> Self {
+    pub fn new(provider: C, blobs: B, cfg: &RollupConfig) -> Self {
         Self {
             chain_provider: provider,
             blob_provider: blobs,
@@ -60,21 +60,17 @@ where
     ) -> Result<Self::DataIter> {
         let ecotone_enabled =
             self.ecotone_timestamp.map(|e| block_ref.timestamp >= e).unwrap_or(false);
-        let chain_provider =
-            self.chain_provider.clone().ok_or_else(|| anyhow!("No chain provider available"))?;
         if ecotone_enabled {
-            let blob_provider =
-                self.blob_provider.clone().ok_or_else(|| anyhow!("No blob provider available"))?;
             Ok(EthereumDataSourceVariant::Blob(BlobSource::new(
-                chain_provider,
-                blob_provider,
+                self.chain_provider.clone(),
+                self.blob_provider.clone(),
                 batcher_address,
                 *block_ref,
                 self.signer,
             )))
         } else {
             Ok(EthereumDataSourceVariant::Calldata(CalldataSource::new(
-                chain_provider,
+                self.chain_provider.clone(),
                 batcher_address,
                 *block_ref,
                 self.signer,


### PR DESCRIPTION
**Description**

Fixes the ethereum data source to default to a calldata-based provider if the ecotone timestamp is not set, following the [reference implementation](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/data_source.go#L75-L82).