### PR TITLE
fix(derive): Remove Duplicate Online Feature Attribute

### DIFF
--- a/crates/derive/src/online/mod.rs
+++ b/crates/derive/src/online/mod.rs
@@ -33,7 +33,6 @@ pub type OnlineAttributesQueue<DAP> = AttributesQueue<
 >;
 
 /// Creates a new online stack.
-#[cfg(feature = "online")]
 pub fn new_online_stack<DAP>(
     rollup_config: Arc<RollupConfig>,
     chain_provider: AlloyChainProvider<ReqwestProvider>,


### PR DESCRIPTION
**Description**

Removes a duplicate `online` attribute config inside the `online` module.