### PR TITLE
feat(examples): basic multi-arch client program setup

### DIFF
--- a/.github/workflows/fpvm-tests.yaml
+++ b/.github/workflows/fpvm-tests.yaml
@@ -36,8 +36,8 @@ jobs:
         with:
           name: images-${{ matrix.fpvm }}
           path: |
-            examples/minimal/target/${{ matrix.fpvm == 'cannon' && 'mips-unknown-none' || 'riscv64gc-unknown-none-elf' }}/release/minimal
-            examples/simple-revm/target/${{ matrix.fpvm == 'cannon' && 'mips-unknown-none' || 'riscv64gc-unknown-none-elf' }}/release/simple-revm
+            target/${{ matrix.fpvm == 'cannon' && 'mips-unknown-none' || 'riscv64gc-unknown-none-elf' }}/release-client/minimal
+            target/${{ matrix.fpvm == 'cannon' && 'mips-unknown-none' || 'riscv64gc-unknown-none-elf' }}/release-client/simple-revm
   fpvm-example-tests:
     needs: build-example-programs
     runs-on: ubuntu-latest
@@ -45,6 +45,8 @@ jobs:
     strategy:
       matrix:
         fpvm: ["cannon-go", "cannon-rs", "asterisc"]
+    env:
+      FPVM: ${{ matrix.fpvm }}
     name: ${{ matrix.fpvm }}-tests
     steps:
       - name: Checkout sources
@@ -93,8 +95,9 @@ jobs:
           name: images-${{ contains(matrix.fpvm, 'cannon') && 'cannon' || 'asterisc' }}
       - name: Restore Targets
         run: |
-          mv minimal/target examples/minimal
-          mv simple-revm/target examples/simple-revm
+          mkdir -p fpvm-tests/bin/$FPVM
+          mv minimal fpvm-tests/bin/$FPVM
+          mv simple-revm fpvm-tests/bin/$FPVM
       - name: Run FPVM tests
         working-directory: ./fpvm-tests
         run: just test-${{ matrix.fpvm }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ target
 
 # Example targets
 examples/**/target
+fpvm-tests/bin
 
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aef7712851e524f35fbbb74fa6599c5cd8692056a1c36f9ca0d2001b670e7e5"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,7 +1576,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "spin",
+ "spin 0.9.8",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1653,6 +1663,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
@@ -1719,6 +1732,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal"
+version = "0.1.0"
+dependencies = [
+ "kona-common",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1787,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,11 +1812,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2212,6 +2278,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter",
+ "revm-precompile",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
+dependencies = [
+ "revm-primitives",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
+dependencies = [
+ "aurora-engine-modexp",
+ "k256",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
 name = "revm-primitives"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2343,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2528,6 +2640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-revm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kona-common",
+ "kona-preimage",
+ "revm",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2673,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2591,6 +2719,19 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["crates/*", "bin/host"]
-exclude = ["examples/minimal", "examples/simple-revm", "fpvm-tests/cannon-rs-tests"]
+members = ["crates/*", "bin/host", "examples/*"]
+exclude = ["fpvm-tests/cannon-rs-tests"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,9 @@ overflow-checks = false
 
 [profile.bench]
 debug = true
+
+[profile.release-client]
+inherits = "release"
+panic = "abort"
+codegen-units = 1
+lto = "fat"

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -1,13 +1,8 @@
 [package]
 name = "minimal"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [dependencies]
 kona-common = { path = "../../crates/common" }
-
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -1,19 +1,26 @@
 #![no_std]
-#![no_main]
+#![cfg_attr(any(target_arch = "mips", target_arch = "riscv64"), no_main)]
 
 use kona_common::io;
 
 extern crate alloc;
 
+#[allow(dead_code)]
 const HEAP_SIZE: usize = 0xFFFFFFF;
 
-#[no_mangle]
-pub extern "C" fn _start() {
+fn main() {
     kona_common::alloc_heap!(HEAP_SIZE);
     io::print("Hello, world!\n");
     io::exit(0)
 }
 
+#[cfg(any(target_arch = "mips", target_arch = "riscv64"))]
+#[no_mangle]
+pub extern "C" fn _start() {
+    main()
+}
+
+#[cfg(any(target_arch = "mips", target_arch = "riscv64"))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     let msg = alloc::format!("Panic: {}", info);

--- a/examples/simple-revm/Cargo.lock
+++ b/examples/simple-revm/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0a6b588ef4aec1b5ddbbfdacd9ef04e00b979617765b03174318ee1f3a"
+checksum = "525448f6afc1b70dd0f9d0a8145631bf2f5e434678ab23ab18409ca264cae6b3"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -385,7 +385,7 @@ dependencies = [
 name = "kona-preimage"
 version = "0.0.1"
 dependencies = [
- "alloy-primitives 0.7.0",
+ "alloy-primitives 0.7.2",
  "anyhow",
  "cfg-if",
  "kona-common",

--- a/examples/simple-revm/Cargo.toml
+++ b/examples/simple-revm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = { version = "1.0.79", default-features = false }
 kona-common = { path = "../../crates/common" }
 kona-preimage = { path = "../../crates/preimage" }
-revm = { version = "4.0.0", default-features = false }
+revm = { version = "8.0.0", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/examples/simple-revm/Cargo.toml
+++ b/examples/simple-revm/Cargo.toml
@@ -1,18 +1,11 @@
 [package]
 name = "simple-revm"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [dependencies]
-anyhow = { version = "1.0.79", default-features = false }
+anyhow = { version = "1.0.82", default-features = false }
 kona-common = { path = "../../crates/common" }
 kona-preimage = { path = "../../crates/preimage" }
 revm = { version = "8.0.0", default-features = false }
-
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
-codegen-units = 1
-lto = "fat"

--- a/fpvm-tests/asterisc-tests/minimal_test.go
+++ b/fpvm-tests/asterisc-tests/minimal_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMinimal(t *testing.T) {
-	programELF, err := elf.Open("../../examples/minimal/target/riscv64gc-unknown-none-elf/release/minimal")
+	programELF, err := elf.Open("../bin/asterisc/minimal")
 	require.NoError(t, err)
 	defer programELF.Close()
 

--- a/fpvm-tests/asterisc-tests/simple_revm_test.go
+++ b/fpvm-tests/asterisc-tests/simple_revm_test.go
@@ -57,7 +57,7 @@ func rustTestOracle(t *testing.T) (po PreimageOracle, stdOut string, stdErr stri
 }
 
 func TestSimpleRevm(t *testing.T) {
-	programELF, err := elf.Open("../../examples/simple-revm/target/riscv64gc-unknown-none-elf/release/simple-revm")
+	programELF, err := elf.Open("../bin/asterisc/simple-revm")
 	require.NoError(t, err)
 	defer programELF.Close()
 

--- a/fpvm-tests/cannon-go-tests/minimal_test.go
+++ b/fpvm-tests/cannon-go-tests/minimal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMinimal(t *testing.T) {
-	elfProgram, err := elf.Open("../../examples/minimal/target/mips-unknown-none/release/minimal")
+	elfProgram, err := elf.Open("../bin/cannon/minimal")
 	require.NoError(t, err, "open ELF file")
 
 	state, err := mipsevm.LoadELF(elfProgram)

--- a/fpvm-tests/cannon-go-tests/simple_revm_test.go
+++ b/fpvm-tests/cannon-go-tests/simple_revm_test.go
@@ -81,7 +81,7 @@ func rustTestOracle(t *testing.T) (po PreimageOracle, stdOut string, stdErr stri
 }
 
 func TestSimpleRevm(t *testing.T) {
-	elfProgram, err := elf.Open("../../examples/simple-revm/target/mips-unknown-none/release/simple-revm")
+	elfProgram, err := elf.Open("../bin/asterisc/simple-revm")
 	require.NoError(t, err, "open ELF file")
 
 	state, err := mipsevm.LoadELF(elfProgram)

--- a/fpvm-tests/cannon-rs-tests/src/minimal_test.rs
+++ b/fpvm-tests/cannon-rs-tests/src/minimal_test.rs
@@ -8,7 +8,7 @@ use std::io::BufWriter;
 #[test]
 fn test_minimal() {
     let elf_bytes =
-        include_bytes!("../../../examples/minimal/target/mips-unknown-none/release/minimal");
+        include_bytes!("../../bin/cannon/minimal");
     let mut state = load_elf(elf_bytes).unwrap();
     patch_stack(&mut state).unwrap();
 

--- a/fpvm-tests/cannon-rs-tests/src/simple_revm_test.rs
+++ b/fpvm-tests/cannon-rs-tests/src/simple_revm_test.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, io::BufWriter};
 #[test]
 fn test_simple_revm() {
     let elf_bytes = include_bytes!(
-        "../../../examples/simple-revm/target/mips-unknown-none/release/simple-revm"
+        "../../bin/cannon/simple-revm"
     );
     let mut state = load_elf(elf_bytes).unwrap();
     patch_stack(&mut state).unwrap();

--- a/fpvm-tests/justfile
+++ b/fpvm-tests/justfile
@@ -9,13 +9,19 @@ test: build-cannon-examples build-asterisc-examples test-cannon test-asterisc
 
 # Build cannon programs
 build-cannon-examples:
-  @cd ../examples/minimal && just build-cannon --release
-  @cd ../examples/simple-revm && just build-cannon --release
+  @cd ../examples/minimal && just build-cannon --profile release-client
+  @cd ../examples/simple-revm && just build-cannon --profile release-client
+  @mkdir -p bin/cannon
+  @cp ../target/mips-unknown-none/release-client/minimal bin/cannon/minimal
+  @cp ../target/mips-unknown-none/release-client/simple-revm bin/cannon/simple-revm
 
 # Build asterisc programs
 build-asterisc-examples:
-  @cd ../examples/minimal && just build-asterisc --release
-  @cd ../examples/simple-revm && just build-asterisc --release
+  @cd ../examples/minimal && just build-asterisc --profile release-client
+  @cd ../examples/simple-revm && just build-asterisc --profile release-client
+  @mkdir -p bin/asterisc
+  @cp ../target/riscv64gc-unknown-none-elf/release-client/minimal bin/asterisc/minimal
+  @cp ../target/riscv64gc-unknown-none-elf/release-client/simple-revm bin/asterisc/simple-revm
 
 # Test programs on `cannon`
 test-cannon: test-cannon-go test-cannon-rs


### PR DESCRIPTION
## Overview

Moves the `example` client programs into the workspace by adding
conditional `main` and `panic_handler` functions, depending on the
target environment.

As a follow-up, we should add a nice proc macro that hides this
functionality so that client programs can easily be linted and checked
on the native development platform.