### PR TITLE
fix(primitives): use decode_2718() to gracefully handle the tx type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,7 @@ name = "kona-primitives"
 version = "0.0.1"
 dependencies = [
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -16,6 +16,7 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 
 # Alloy Types
 alloy-sol-types = { version = "0.7.1", default-features = false }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "cb95183", default-features = false }
 op-alloy-consensus = { git = "https://github.com/clabby/op-alloy", branch = "refcell/consensus-port", default-features = false }
 
 # `serde` feature dependencies

--- a/crates/primitives/src/payload.rs
+++ b/crates/primitives/src/payload.rs
@@ -140,7 +140,6 @@ impl L2ExecutionPayloadEnvelope {
             if ty != OpTxType::Deposit as u8 {
                 anyhow::bail!("First payload transaction has unexpected type: {:?}", ty);
             }
-
             let tx = OpTxEnvelope::decode_2718(&mut execution_payload.transactions[0].as_ref())
                 .map_err(|e| anyhow::anyhow!(e))?;
 

--- a/crates/primitives/src/payload.rs
+++ b/crates/primitives/src/payload.rs
@@ -1,6 +1,7 @@
 //! Contains the execution payload type.
 
 use alloc::vec::Vec;
+use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use anyhow::Result;
 use op_alloy_consensus::{OpTxEnvelope, OpTxType};
@@ -17,7 +18,7 @@ use super::{
     Block, BlockInfo, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx, L2BlockInfo, OpBlock,
     RollupConfig, SystemConfig, Withdrawal,
 };
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Encodable;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -139,7 +140,8 @@ impl L2ExecutionPayloadEnvelope {
             if ty != OpTxType::Deposit as u8 {
                 anyhow::bail!("First payload transaction has unexpected type: {:?}", ty);
             }
-            let tx = OpTxEnvelope::decode(&mut execution_payload.transactions[0][1..].as_ref())
+
+            let tx = OpTxEnvelope::decode_2718(&mut execution_payload.transactions[0].as_ref())
                 .map_err(|e| anyhow::anyhow!(e))?;
 
             let OpTxEnvelope::Deposit(tx) = tx else {
@@ -183,7 +185,7 @@ impl L2ExecutionPayloadEnvelope {
         if ty != OpTxType::Deposit as u8 {
             anyhow::bail!("First payload transaction has unexpected type: {:?}", ty);
         }
-        let tx = OpTxEnvelope::decode(&mut execution_payload.transactions[0][1..].as_ref())
+        let tx = OpTxEnvelope::decode_2718(&mut execution_payload.transactions[0].as_ref())
             .map_err(|e| anyhow::anyhow!(e))?;
 
         let OpTxEnvelope::Deposit(tx) = tx else {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I believe `decode_2718()` will gracefully remove the transaction type byte, so I imported it from alloy_eips.

**Tests**

I ran all existing tests, including all the decoding unit tests in `stages`.

**Metadata**

- Fixes #147 
