### PR TITLE
fix(ci): Run CI on `pull_request` and `merge_group` triggers

### DIFF
--- a/.github/workflows/cross_docker.yaml
+++ b/.github/workflows/cross_docker.yaml
@@ -1,7 +1,5 @@
 name: Build and Publish Cross Images
-on:
-  workflow_dispatch:
-  workflow_call:
+on: [workflow_dispatch, workflow_call]
 env:
   REGISTRY: ghcr.io
 jobs:

--- a/.github/workflows/fpvm_tests.yaml
+++ b/.github/workflows/fpvm_tests.yaml
@@ -1,5 +1,9 @@
 name: FPVM
-on: [push]
+on:
+  push:
+  merge_group:
+  pull_request:
+    types: [opened, reopened]
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -1,5 +1,9 @@
 name: Rust CI
-on: [push]
+on:
+  push:
+  merge_group:
+  pull_request:
+    types: [opened, reopened]
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
## Overview

Adds extra triggers to the `fpvm-tests` and `rust-ci` workflows that trigger jobs on PR creation / re-opening as well as when a PR is added to the merge queue.

This should fix CI for external contributors, cc @merklefruit