### PR TITLE
chore(workspace): Add aliases in root `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,9 @@
 set positional-arguments
+alias t := tests
+alias l := lint
+alias ln := lint-native
+alias fmt := fmt-native-fix
+alias b := build
 
 # default recipe to display help information
 default:


### PR DESCRIPTION
## Overview

Adds a few aliases in the root just file for common commands used in
local development.