### PR TITLE
feat(mpt): Trie DB commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb28aa4ecd32fdfa1b1bdd111ff7357dd562c6b2372694cf9e613434fcba659"
+checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -18,7 +18,7 @@ alloy-consensus.workspace = true
 revm.workspace = true
 
 # External
-alloy-trie = { version = "0.3.1", default-features = false }
+alloy-trie = { version = "0.4.1", default-features = false }
 smallvec = "1.13"
 
 [dev-dependencies]

--- a/crates/mpt/src/util.rs
+++ b/crates/mpt/src/util.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 use alloy_rlp::{BufMut, Encodable};
-use alloy_trie::{HashBuilder, Nibbles};
+use alloy_trie::{proof::ProofRetainer, HashBuilder, Nibbles};
 
 /// Compute a trie root of the collection of items with a custom encoder.
 pub fn ordered_trie_with_encoder<T, F>(items: &[T], mut encode: F) -> HashBuilder
@@ -23,7 +23,7 @@ where
         })
         .collect::<Vec<_>>();
 
-    let mut hb = HashBuilder::default().with_proof_retainer(path_nibbles);
+    let mut hb = HashBuilder::default().with_proof_retainer(ProofRetainer::new(path_nibbles));
     for i in 0..items_len {
         let index = adjust_index_for_rlp(i, items_len);
 


### PR DESCRIPTION
## Overview

Implements the `TrieCacheDB`'s `DatabaseCommit` trait, recomputing the state root when `commit` is called using the `TrieNode`.
