### PR TITLE
feat(mpt): Simplify `TrieDB`

### DIFF
--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate alloc;
 
 mod db;
-pub use db::{TrieAccount, TrieCacheDB};
+pub use db::{TrieAccount, TrieDB};
 
 mod node;
 pub use node::TrieNode;


### PR DESCRIPTION
## Overview

Simplifies `TrieDB` by assuming it will be wrapped with [`revm::State`](https://github.com/bluealloy/revm/blob/fadf6fbe43a3022c1406c0d8ee062a83e951d4d3/crates/revm/src/db/states/state.rs#L29). The `State` handles the cache layer for in-memory accounts / storage, allowing the `TrieDB` to focus solely on caching open trie state and state root recomputation.

The `State` struct in `revm` is better for our usecase, since it allows for merging a `BundleState` after a full block's execution. The previous implementation had the fatal flaw having to recompute the state root every time the `DatabaseCommit` trait implementation was invoked, which was not suitable.

Examples of usage may be found within the rustdoc for `TrieDB`.
