### PR TITLE
chore(ci): Workflow trigger changes

### DIFF
--- a/.github/workflows/fpvm_tests.yaml
+++ b/.github/workflows/fpvm_tests.yaml
@@ -1,9 +1,9 @@
 name: FPVM
 on:
   push:
+    branches: [main]
   merge_group:
   pull_request:
-    types: [opened, reopened]
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -1,9 +1,9 @@
 name: Rust CI
 on:
   push:
+    branches: [main]
   merge_group:
   pull_request:
-    types: [opened, reopened]
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
## Overview

Alters the workflow triggers such that the `push` trigger only runs when the PR is merged into `main`, and the `pull_request` trigger is agnostic to the `type`. This prevents double-runs of CI workflows in the merge queue / upon PR creation.
