### PR TITLE
chore: Refactor ResetProvider

### DIFF
--- a/crates/derive/src/builder.rs
+++ b/crates/derive/src/builder.rs
@@ -2,23 +2,12 @@
 
 use crate::{
     stages::NextAttributes,
-    traits::{OriginAdvancer, ResettableStage},
+    traits::{OriginAdvancer, ResetProvider, ResettableStage},
     types::{StageError, StageResult},
 };
-use alloc::{boxed::Box, collections::VecDeque};
-use async_trait::async_trait;
+use alloc::collections::VecDeque;
 use core::fmt::Debug;
 use kona_primitives::{BlockInfo, L2AttributesWithParent, L2BlockInfo, SystemConfig};
-
-/// Provides the [BlockInfo] and [SystemConfig] for the stack to reset the stages.
-#[async_trait]
-pub trait ResetProvider {
-    /// Returns the current [BlockInfo] for the pipeline to reset.
-    async fn block_info(&self) -> BlockInfo;
-
-    /// Returns the current [SystemConfig] for the pipeline to reset.
-    async fn system_config(&self) -> SystemConfig;
-}
 
 /// The derivation pipeline is responsible for deriving L2 inputs from L1 data.
 #[derive(Debug)]

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -2,7 +2,10 @@
 //! pipeline.
 
 mod data_sources;
-pub use data_sources::*;
+pub use data_sources::{AsyncIterator, BlobProvider, DataAvailabilityProvider};
+
+mod reset;
+pub use reset::ResetProvider;
 
 mod providers;
 pub use providers::{ChainProvider, L2ChainProvider};

--- a/crates/derive/src/traits/reset.rs
+++ b/crates/derive/src/traits/reset.rs
@@ -1,0 +1,15 @@
+//! Traits for resetting stages.
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
+use kona_primitives::{BlockInfo, SystemConfig};
+
+/// Provides the [BlockInfo] and [SystemConfig] for the stack to reset the stages.
+#[async_trait]
+pub trait ResetProvider {
+    /// Returns the current [BlockInfo] for the pipeline to reset.
+    async fn block_info(&self) -> BlockInfo;
+
+    /// Returns the current [SystemConfig] for the pipeline to reset.
+    async fn system_config(&self) -> SystemConfig;
+}


### PR DESCRIPTION
**Description**

Refactors the `ResetProvider` in preparation for a pulling a default impl out of `kona-exex` and into `kona-derive`.