### PR TITLE
feat: Pipeline Builder

### DIFF
--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -13,9 +13,7 @@ pub use params::{
     MAX_RLP_BYTES_PER_CHANNEL, MAX_SPAN_BATCH_BYTES, SEQUENCER_FEE_VAULT_ADDRESS,
 };
 
-pub mod builder;
-pub use builder::DerivationPipeline;
-
+pub mod pipeline;
 pub mod sources;
 pub mod stages;
 pub mod traits;

--- a/crates/derive/src/pipeline/builder.rs
+++ b/crates/derive/src/pipeline/builder.rs
@@ -1,0 +1,67 @@
+//! Contains the `PipelineBuilder` object that is used to build a `DerivationPipeline`.
+
+use super::{DerivationPipeline, NextAttributes, OriginAdvancer, ResetProvider, ResettableStage};
+use alloc::collections::VecDeque;
+use core::fmt::Debug;
+use kona_primitives::L2BlockInfo;
+
+/// The PipelineBuilder constructs a [DerivationPipeline].
+#[derive(Debug)]
+pub struct PipelineBuilder<S, R>
+where
+    S: NextAttributes + ResettableStage + OriginAdvancer + Debug + Send,
+    R: ResetProvider + Send,
+{
+    attributes: Option<S>,
+    reset: Option<R>,
+    start_cursor: Option<L2BlockInfo>,
+}
+
+impl<S, R> PipelineBuilder<S, R>
+where
+    S: NextAttributes + ResettableStage + OriginAdvancer + Debug + Send,
+    R: ResetProvider + Send,
+{
+    /// Sets the attributes for the pipeline.
+    pub fn attributes(mut self, attributes: S) -> Self {
+        self.attributes = Some(attributes);
+        self
+    }
+
+    /// Sets the reset provider for the pipeline.
+    pub fn reset(mut self, reset: R) -> Self {
+        self.reset = Some(reset);
+        self
+    }
+
+    /// Sets the start cursor for the pipeline.
+    pub fn start_cursor(mut self, cursor: L2BlockInfo) -> Self {
+        self.start_cursor = Some(cursor);
+        self
+    }
+
+    /// Builds the pipeline.
+    pub fn build(self) -> DerivationPipeline<S, R> {
+        self.into()
+    }
+}
+
+impl<S, R> From<PipelineBuilder<S, R>> for DerivationPipeline<S, R>
+where
+    S: NextAttributes + ResettableStage + OriginAdvancer + Debug + Send,
+    R: ResetProvider + Send,
+{
+    fn from(builder: PipelineBuilder<S, R>) -> Self {
+        let attributes = builder.attributes.expect("attributes must be set");
+        let reset = builder.reset.expect("reset must be set");
+        let start_cursor = builder.start_cursor.expect("start_cursor must be set");
+
+        DerivationPipeline {
+            attributes,
+            reset,
+            prepared: VecDeque::new(),
+            needs_reset: false,
+            cursor: start_cursor,
+        }
+    }
+}

--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -1,0 +1,13 @@
+//! Module containing the derivation pipeline.
+
+/// Re-export trait arguments.
+pub use crate::traits::{NextAttributes, OriginAdvancer, Pipeline, ResetProvider, ResettableStage};
+
+/// Re-export commonly used types.
+pub use crate::types::{StageError, StageResult};
+
+mod builder;
+pub use builder::PipelineBuilder;
+
+mod core;
+pub use core::DerivationPipeline;

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -1,7 +1,7 @@
 //! Contains the logic for the `AttributesQueue` stage.
 
 use crate::{
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{NextAttributes, OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
     types::{
         BlockInfo, L2AttributesWithParent, L2BlockInfo, L2PayloadAttributes, ResetError,
         RollupConfig, SingleBatch, StageError, StageResult, SystemConfig,
@@ -28,14 +28,6 @@ pub trait AttributesProvider {
 
     /// Returns whether the current batch is the last in its span.
     fn is_last_in_span(&self) -> bool;
-}
-
-/// [NextAttributes] is a trait abstraction that generalizes the [AttributesQueue] stage.
-#[async_trait]
-pub trait NextAttributes {
-    /// Returns the next [L2AttributesWithParent] from the current batch.
-    async fn next_attributes(&mut self, parent: L2BlockInfo)
-        -> StageResult<L2AttributesWithParent>;
 }
 
 /// [AttributesQueue] accepts batches from the [BatchQueue] stage

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -33,8 +33,7 @@ pub use batch_queue::{BatchQueue, BatchQueueProvider};
 
 mod attributes_queue;
 pub use attributes_queue::{
-    AttributesBuilder, AttributesProvider, AttributesQueue, NextAttributes,
-    StatefulAttributesBuilder,
+    AttributesBuilder, AttributesProvider, AttributesQueue, StatefulAttributesBuilder,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/derive/src/traits/attributes.rs
+++ b/crates/derive/src/traits/attributes.rs
@@ -1,0 +1,14 @@
+//! Contains traits for working with payload attributes and their providers.
+
+use crate::types::{L2AttributesWithParent, L2BlockInfo, StageResult};
+use alloc::boxed::Box;
+use async_trait::async_trait;
+
+/// [NextAttributes] defines the interface for pulling attributes from
+/// the top level `AttributesQueue` stage of the pipeline.
+#[async_trait]
+pub trait NextAttributes {
+    /// Returns the next [L2AttributesWithParent] from the current batch.
+    async fn next_attributes(&mut self, parent: L2BlockInfo)
+        -> StageResult<L2AttributesWithParent>;
+}

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -1,6 +1,12 @@
 //! This module contains all of the traits describing functionality of portions of the derivation
 //! pipeline.
 
+mod pipeline;
+pub use pipeline::Pipeline;
+
+mod attributes;
+pub use attributes::NextAttributes;
+
 mod data_sources;
 pub use data_sources::{AsyncIterator, BlobProvider, DataAvailabilityProvider};
 

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -1,0 +1,22 @@
+//! Defines the interface for the core derivation pipeline.
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
+use kona_primitives::{L2AttributesWithParent, L2BlockInfo};
+
+/// This trait defines the interface for interacting with the derivation pipeline.
+#[async_trait]
+pub trait Pipeline {
+    /// Resets the pipeline on the next [Pipeline::step] call.
+    fn reset(&mut self);
+
+    /// Attempts to progress the pipeline.
+    async fn step(&mut self) -> anyhow::Result<()>;
+
+    /// Pops the next prepared [L2AttributesWithParent] from the pipeline.
+    fn pop(&mut self) -> Option<L2AttributesWithParent>;
+
+    /// Updates the L2 Safe Head cursor of the pipeline.
+    /// This is used when fetching the next attributes.
+    fn update_cursor(&mut self, cursor: L2BlockInfo);
+}


### PR DESCRIPTION
**Description**

Refactors the derivation pipeline into it's own module with a builder.

A few previously siloed traits were pulled into the `traits` module and re-exported where needed.

On top of this pr, will be stacked a few refactors to the online helper methods and implementations.