### PR TITLE
chore: Alloy Withdrawal Type

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -2,7 +2,8 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::{Header, TxEnvelope};
-use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
+use alloy_eips::eip4895::Withdrawal;
+use alloy_primitives::{BlockHash, BlockNumber, B256};
 
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use op_alloy_consensus::OpTxEnvelope;
@@ -131,20 +132,4 @@ pub struct OpBlock {
     pub ommers: Vec<Header>,
     /// Block withdrawals.
     pub withdrawals: Option<Vec<Withdrawal>>,
-}
-
-/// Withdrawal represents a validator withdrawal from the consensus layer.
-///
-/// Taken from [reth-primitives](https://github.com/paradigmxyz/reth)
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, RlpEncodable, RlpDecodable)]
-pub struct Withdrawal {
-    /// Monotonically increasing identifier issued by consensus layer.
-    pub index: u64,
-    /// Index of validator associated with withdrawal.
-    pub validator_index: u64,
-    /// Target address for withdrawn ether.
-    pub address: Address,
-    /// Value of the withdrawal in gwei.
-    pub amount: u64,
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,8 +6,13 @@
 
 extern crate alloc;
 
+/// Re-export the [Withdrawal] type from the [alloy_eips] crate.
+///
+/// [Withdrawal]: alloy_eips::eip4895::Withdrawal
+pub use alloy_eips::eip4895::Withdrawal;
+
 pub mod block;
-pub use block::{Block, BlockID, BlockInfo, BlockKind, L2BlockInfo, OpBlock, Withdrawal};
+pub use block::{Block, BlockID, BlockInfo, BlockKind, L2BlockInfo, OpBlock};
 
 pub mod block_info;
 pub use block_info::{L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx};


### PR DESCRIPTION
**Description**

Removes the custom `Withdrawal` type definition, replacing it with the [`alloy_eips::eip4895::Withdrawal`](https://github.com/alloy-rs/alloy/blob/main/crates/eips/src/eip4895.rs#L21) type.

Fixes #212.