### PR TITLE
fix(derive): Alloy EIP4844 Blob Type

### DIFF
--- a/crates/derive/src/types/blob.rs
+++ b/crates/derive/src/types/blob.rs
@@ -1,7 +1,8 @@
 //! EIP4844 Blob Type
 
 use alloc::vec::Vec;
-use alloy_primitives::{Bytes, FixedBytes, B256};
+use alloy_eips::eip4844::Blob;
+use alloy_primitives::{Bytes, B256};
 use anyhow::Result;
 
 /// The blob encoding version
@@ -18,9 +19,6 @@ pub(crate) const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4; // 130044
 
 /// Blob Encoding/Decoding Rounds
 pub(crate) const BLOB_ENCODING_ROUNDS: usize = 1024;
-
-/// A Blob serialized as 0x-prefixed hex string
-pub type Blob = FixedBytes<BLOB_BYTES_SIZE>;
 
 /// A Blob hash
 #[derive(Default, Clone, Debug)]

--- a/crates/derive/src/types/blob.rs
+++ b/crates/derive/src/types/blob.rs
@@ -1,18 +1,13 @@
 //! EIP4844 Blob Type
 
 use alloc::vec::Vec;
-use alloy_eips::eip4844::Blob;
 use alloy_primitives::{Bytes, B256};
 use anyhow::Result;
 
+use super::{Blob, BYTES_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
+
 /// The blob encoding version
 pub(crate) const BLOB_ENCODING_VERSION: u8 = 0;
-
-/// The version offset in the blob
-pub(crate) const BLOB_VERSION_OFFSET: usize = 1;
-
-/// How many bytes are in a blob
-pub(crate) const BLOB_BYTES_SIZE: usize = 4096 * 32; // 131072
 
 /// Maximum blob data size
 pub(crate) const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4; // 130044
@@ -65,7 +60,7 @@ impl BlobData {
         let data = self.data.as_ref().ok_or(BlobDecodingError::MissingData)?;
 
         // Validate the blob encoding version
-        if data[BLOB_VERSION_OFFSET] != BLOB_ENCODING_VERSION {
+        if data[VERSIONED_HASH_VERSION_KZG as usize] != BLOB_ENCODING_VERSION {
             return Err(BlobDecodingError::InvalidEncodingVersion);
         }
 
@@ -126,7 +121,7 @@ impl BlobData {
 
         // Validate the remaining bytes
         output.truncate(length);
-        for i in input_pos..BLOB_BYTES_SIZE {
+        for i in input_pos..BYTES_PER_BLOB {
             if data[i] != 0 {
                 return Err(BlobDecodingError::InvalidFieldElement);
             }

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -12,11 +12,14 @@ pub use batch::{
     MAX_SPAN_BATCH_SIZE,
 };
 
+/// Re-export eip4844 primitives.
+pub use alloy_eips::eip4844::Blob;
+
 mod ecotone;
 pub use ecotone::*;
 
 mod blob;
-pub use blob::{Blob, BlobData, BlobDecodingError, IndexedBlobHash};
+pub use blob::{BlobData, BlobDecodingError, IndexedBlobHash};
 
 mod sidecar;
 pub use sidecar::{

--- a/crates/derive/src/types/mod.rs
+++ b/crates/derive/src/types/mod.rs
@@ -13,7 +13,7 @@ pub use batch::{
 };
 
 /// Re-export eip4844 primitives.
-pub use alloy_eips::eip4844::Blob;
+pub use alloy_eips::eip4844::{Blob, BYTES_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
 
 mod ecotone;
 pub use ecotone::*;

--- a/crates/derive/src/types/sidecar.rs
+++ b/crates/derive/src/types/sidecar.rs
@@ -1,7 +1,7 @@
 //! Contains sidecar types for blobs.
 
-use crate::types::Blob;
 use alloc::{string::String, vec::Vec};
+use alloy_eips::eip4844::Blob;
 use alloy_primitives::FixedBytes;
 
 #[cfg(feature = "online")]


### PR DESCRIPTION
**Description**

Replaces `kona-derive` custom `Blob` type with `alloy_eips` 4844 Blob type.

**Metadata**

Fixes #214.