### PR TITLE
feat(client): Account + Account storage hinting in `TrieDB`

### DIFF
--- a/bin/host/src/fetcher/hint.rs
+++ b/bin/host/src/fetcher/hint.rs
@@ -19,12 +19,17 @@ pub enum HintType {
     L2BlockHeader,
     /// A hint that specifies the transactions of a layer 2 block.
     L2Transactions,
-    /// A hint that specifies the state node in the L2 state trie.
-    L2StateNode,
     /// A hint that specifies the code of a contract on layer 2.
     L2Code,
     /// A hint that specifies the output root of a block on layer 2.
     L2Output,
+    /// A hint that specifies the state node in the L2 state trie.
+    L2StateNode,
+    /// A hint that specifies the proof on the path to an account in the L2 state trie.
+    L2AccountProof,
+    /// A hint that specifies the proof on the path to a storage slot in an account within in the
+    /// L2 state trie.
+    L2AccountStorageProof,
 }
 
 impl TryFrom<&str> for HintType {
@@ -39,9 +44,11 @@ impl TryFrom<&str> for HintType {
             "l1-precompile" => Ok(HintType::L1Precompile),
             "l2-block-header" => Ok(HintType::L2BlockHeader),
             "l2-transactions" => Ok(HintType::L2Transactions),
-            "l2-state-node" => Ok(HintType::L2StateNode),
             "l2-code" => Ok(HintType::L2Code),
             "l2-output" => Ok(HintType::L2Output),
+            "l2-state-node" => Ok(HintType::L2StateNode),
+            "l2-account-proof" => Ok(HintType::L2AccountProof),
+            "l2-account-storage-proof" => Ok(HintType::L2AccountStorageProof),
             _ => anyhow::bail!("Invalid hint type: {value}"),
         }
     }
@@ -57,9 +64,11 @@ impl From<HintType> for &str {
             HintType::L1Precompile => "l1-precompile",
             HintType::L2BlockHeader => "l2-block-header",
             HintType::L2Transactions => "l2-transactions",
-            HintType::L2StateNode => "l2-state-node",
             HintType::L2Code => "l2-code",
             HintType::L2Output => "l2-output",
+            HintType::L2StateNode => "l2-state-node",
+            HintType::L2AccountProof => "l2-account-proof",
+            HintType::L2AccountStorageProof => "l2-account-storage-proof",
         }
     }
 }

--- a/bin/programs/client/src/l2/mod.rs
+++ b/bin/programs/client/src/l2/mod.rs
@@ -2,4 +2,4 @@
 //! [StatelessL2BlockExecutor]
 
 mod executor;
-pub use executor::{StatelessL2BlockExecutor, TrieDBProvider};
+pub use executor::{StatelessL2BlockExecutor, TrieDBHintWriter, TrieDBProvider};

--- a/crates/mpt/src/fetcher.rs
+++ b/crates/mpt/src/fetcher.rs
@@ -2,7 +2,7 @@
 //! headers.
 
 use alloy_consensus::Header;
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use anyhow::Result;
 
 /// The [TrieDBFetcher] trait defines the synchronous interface for fetching trie node preimages and
@@ -45,6 +45,43 @@ pub trait TrieDBFetcher {
     fn header_by_hash(&self, hash: B256) -> Result<Header>;
 }
 
+/// The [TrieDBHinter] trait defines the synchronous interface for hinting the host to fetch trie
+/// node preimages.
+pub trait TrieDBHinter {
+    /// Hints the host to fetch the trie node preimage by hash.
+    ///
+    /// ## Takes
+    /// - `hash`: The hash of the trie node to hint.
+    ///
+    /// ## Returns
+    /// - Ok(()): If the hint was successful.
+    fn hint_trie_node(&self, hash: B256) -> Result<()>;
+
+    /// Hints the host to fetch the trie node preimages on the path to the given address.
+    ///
+    /// ## Takes
+    /// - `address` - The address of the contract whose trie node preimages are to be fetched.
+    /// - `block_number` - The block number at which the trie node preimages are to be fetched.
+    ///
+    /// ## Returns
+    /// - Ok(()): If the hint was successful.
+    /// - Err(anyhow::Error): If the hint was unsuccessful.
+    fn hint_account_proof(&self, address: Address, block_number: u64) -> Result<()>;
+
+    /// Hints the host to fetch the trie node preimages on the path to the storage slot within the
+    /// given account's storage trie.
+    ///
+    /// ## Takes
+    /// - `address` - The address of the contract whose trie node preimages are to be fetched.
+    /// - `slot` - The storage slot whose trie node preimages are to be fetched.
+    /// - `block_number` - The block number at which the trie node preimages are to be fetched.
+    ///
+    /// ## Returns
+    /// - Ok(()): If the hint was successful.
+    /// - Err(anyhow::Error): If the hint was unsuccessful.
+    fn hint_storage_proof(&self, address: Address, slot: U256, block_number: u64) -> Result<()>;
+}
+
 /// The default, no-op implementation of the [TrieDBFetcher] trait, used for testing.
 #[derive(Debug, Clone, Copy)]
 pub struct NoopTrieDBFetcher;
@@ -60,5 +97,23 @@ impl TrieDBFetcher for NoopTrieDBFetcher {
 
     fn header_by_hash(&self, _hash: B256) -> Result<Header> {
         Ok(Header::default())
+    }
+}
+
+/// The default, no-op implementation of the [TrieDBHinter] trait, used for testing.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopTrieDBHinter;
+
+impl TrieDBHinter for NoopTrieDBHinter {
+    fn hint_trie_node(&self, _hash: B256) -> Result<()> {
+        Ok(())
+    }
+
+    fn hint_account_proof(&self, _address: Address, _block_number: u64) -> Result<()> {
+        Ok(())
+    }
+
+    fn hint_storage_proof(&self, _address: Address, _slot: U256, _block_number: u64) -> Result<()> {
+        Ok(())
     }
 }

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -10,7 +10,7 @@ mod db;
 pub use db::{TrieAccount, TrieDB};
 
 mod fetcher;
-pub use fetcher::{NoopTrieDBFetcher, TrieDBFetcher};
+pub use fetcher::{NoopTrieDBFetcher, NoopTrieDBHinter, TrieDBFetcher, TrieDBHinter};
 
 mod node;
 pub use node::TrieNode;


### PR DESCRIPTION
## Overview

Introcues the `TrieDBHinter` trait, which outlines an interface for sending hints to the host for trie account proofs and storage slot proofs. This enables `kona-host` to use `eth_getProof` rather than the very limited `debug_dbGet` for fetching most of the intermediate trie nodes during L2 execution.

**Caveat**: We do still need some sort of trie-node-by-hash function in order to fetch siblings within branches during node deletion. `debug_dbGet` works for hash-scheme geth nodes, though it is the only option at the moment. Might be time to build an indexer on reth to cache intermediate trie nodes.
