### PR TITLE
feat(derive): Remove Manual Pipeline Origin Set

### DIFF
--- a/bin/programs/client/src/l1/driver.rs
+++ b/bin/programs/client/src/l1/driver.rs
@@ -100,7 +100,7 @@ impl DerivationDriver {
         let cfg = Arc::new(boot_info.rollup_config.clone());
 
         // Fetch the startup information.
-        let (l1_origin, l2_safe_head, l2_safe_head_header) = Self::find_startup_info(
+        let (_, l2_safe_head, l2_safe_head_header) = Self::find_startup_info(
             caching_oracle,
             boot_info,
             &mut chain_provider,
@@ -121,7 +121,6 @@ impl DerivationDriver {
             .l2_chain_provider(l2_chain_provider)
             .chain_provider(chain_provider)
             .builder(attributes)
-            .origin(l1_origin)
             .build();
 
         Ok(Self { l2_safe_head, l2_safe_head_header, pipeline })

--- a/crates/derive/src/online/pipeline.rs
+++ b/crates/derive/src/online/pipeline.rs
@@ -1,7 +1,7 @@
 //! Contains online pipeline types.
 
 use super::{
-    AlloyChainProvider, AlloyL2ChainProvider, BlockInfo, DerivationPipeline, EthereumDataSource,
+    AlloyChainProvider, AlloyL2ChainProvider, DerivationPipeline, EthereumDataSource,
     OnlineBeaconClient, OnlineBlobProvider, PipelineBuilder, RollupConfig, SimpleSlotDerivation,
     StatefulAttributesBuilder,
 };
@@ -43,7 +43,6 @@ pub fn new_online_pipeline(
     dap_source: OnlineDataProvider,
     l2_chain_provider: AlloyL2ChainProvider,
     builder: OnlineAttributesBuilder,
-    origin: BlockInfo,
 ) -> OnlinePipeline {
     PipelineBuilder::new()
         .rollup_config(rollup_config)
@@ -51,6 +50,5 @@ pub fn new_online_pipeline(
         .l2_chain_provider(l2_chain_provider)
         .chain_provider(chain_provider)
         .builder(builder)
-        .origin(origin)
         .build()
 }

--- a/crates/derive/src/pipeline/builder.rs
+++ b/crates/derive/src/pipeline/builder.rs
@@ -8,7 +8,7 @@ use crate::stages::{
 };
 use alloc::sync::Arc;
 use core::fmt::Debug;
-use kona_primitives::{BlockInfo, RollupConfig};
+use kona_primitives::RollupConfig;
 
 type L1TraversalStage<P> = L1Traversal<P>;
 type L1RetrievalStage<DAP, P> = L1Retrieval<DAP, L1TraversalStage<P>>;
@@ -32,7 +32,6 @@ where
     dap_source: Option<D>,
     chain_provider: Option<P>,
     builder: Option<B>,
-    origin: Option<BlockInfo>,
     rollup_config: Option<Arc<RollupConfig>>,
 }
 
@@ -49,7 +48,6 @@ where
             dap_source: None,
             chain_provider: None,
             builder: None,
-            origin: None,
             rollup_config: None,
         }
     }
@@ -70,12 +68,6 @@ where
     /// Sets the rollup config for the pipeline.
     pub fn rollup_config(mut self, rollup_config: Arc<RollupConfig>) -> Self {
         self.rollup_config = Some(rollup_config);
-        self
-    }
-
-    /// Sets the origin L1 block for the pipeline.
-    pub fn origin(mut self, origin: BlockInfo) -> Self {
-        self.origin = Some(origin);
         self
     }
 
@@ -126,8 +118,7 @@ where
         let attributes_builder = builder.builder.expect("builder must be set");
 
         // Compose the stage stack.
-        let mut l1_traversal = L1Traversal::new(chain_provider, Arc::clone(&rollup_config));
-        l1_traversal.block = Some(builder.origin.expect("origin must be set"));
+        let l1_traversal = L1Traversal::new(chain_provider, Arc::clone(&rollup_config));
         let l1_retrieval = L1Retrieval::new(l1_traversal, dap_source);
         let frame_queue = FrameQueue::new(l1_retrieval);
         let channel_bank = ChannelBank::new(Arc::clone(&rollup_config), frame_queue);

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -150,7 +150,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_l1_retrieval_origin() {
-        let traversal = new_populated_test_traversal();
+        let mut traversal = new_populated_test_traversal();
+        let _ = traversal.advance_origin().await;
         let dap = TestDAP { results: vec![], batch_inbox_address: Address::default() };
         let retrieval = L1Retrieval::new(traversal, dap);
         let expected = BlockInfo::default();

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -40,7 +40,7 @@ async fn sync(cli_cfg: crate::cli::Cli) -> Result<()> {
     // Construct the pipeline and payload validator.
     let cfg = Arc::new(OP_MAINNET_CONFIG);
     let start = cli_cfg.start_l2_block.unwrap_or(cfg.genesis.l2.number);
-    let mut l1_provider = AlloyChainProvider::new_http(l1_rpc_url);
+    let l1_provider = AlloyChainProvider::new_http(l1_rpc_url);
     let mut l2_provider = AlloyL2ChainProvider::new_http(l2_rpc_url.clone(), cfg.clone());
     let attributes =
         StatefulAttributesBuilder::new(cfg.clone(), l2_provider.clone(), l1_provider.clone());
@@ -52,13 +52,8 @@ async fn sync(cli_cfg: crate::cli::Cli) -> Result<()> {
         .l2_block_info_by_number(start)
         .await
         .expect("Failed to fetch genesis L2 block info for pipeline cursor");
-    let tip = l1_provider
-        .block_info_by_number(cursor.l1_origin.number)
-        .await
-        .expect("Failed to fetch genesis L1 block info for pipeline tip");
     let validator = validation::OnlineValidator::new_http(l2_rpc_url.clone(), &cfg);
-    let mut pipeline =
-        new_online_pipeline(cfg, l1_provider, dap, l2_provider.clone(), attributes, tip);
+    let mut pipeline = new_online_pipeline(cfg, l1_provider, dap, l2_provider.clone(), attributes);
     let mut derived_attributes_count = 0;
 
     // Continuously step on the pipeline and validate payloads.


### PR DESCRIPTION
**Description**

Removes the need to set the L1 origin on the `L1Traversal` stage of the pipeline.

Updates associated broken tests.

**Metadata**

Fixes #254 