### PR TITLE
fix(common): Synchronize file to disk in `NativeIO`

### DIFF
--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -86,6 +86,10 @@ mod native_io {
             file.seek(SeekFrom::Current(-(n as i64)))
                 .map_err(|e| anyhow!("Failed to reset file cursor to 0: {e}"))?;
 
+            // Attempt to sync the file to disk. This is a best-effort operation and should not
+            // throw if it fails.
+            let _ = file.sync_all();
+
             Ok(n)
         }
 
@@ -97,6 +101,10 @@ mod native_io {
             };
             let n =
                 file.read(buf).map_err(|e| anyhow!("Error reading from file descriptor: {e}"))?;
+
+            // Attempt to sync the file to disk. This is a best-effort operation and should not
+            // throw if it fails.
+            let _ = file.sync_all();
 
             Ok(n)
         }


### PR DESCRIPTION
## Overview

Fixes a rare synchronization error in the `NativeIO`, where when fetching is happening very fast concurrently, the file's contents may not be synced to disk fast enough for the other end of the pipe to recognize. Notably, `std::fs::File` _does not block_ on updating the metadata of the file to disk when it is being dropped. `File::sync_all` does exactly this, blocking until all metadata and in-memory contents have been flushed to disk.
