### PR TITLE
feat(preimage): add serde feature flag to preimage crate for keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "kona-common",
+ "serde",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -19,7 +19,7 @@ async-trait.workspace = true
 # local
 kona-common = { path = "../common", version = "0.0.1" }
 
-serde = { version = "1.0.203", optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.38.0", features = ["full"] }

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -27,4 +27,4 @@ tempfile = "3.10.1"
 
 [features]
 default = []
-serde = ["serde"]
+serde = ["dep:serde"]

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -19,6 +19,12 @@ async-trait.workspace = true
 # local
 kona-common = { path = "../common", version = "0.0.1" }
 
+serde = { version = "1.0.203", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1.38.0", features = ["full"] }
 tempfile = "3.10.1"
+
+[features]
+default = []
+serde = ["serde"]

--- a/crates/preimage/src/key.rs
+++ b/crates/preimage/src/key.rs
@@ -2,8 +2,11 @@
 //! the preimage oracle.
 
 use alloy_primitives::{B256, U256};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// <https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-key-types>
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u8)]
 pub enum PreimageKeyType {
@@ -53,6 +56,7 @@ impl TryFrom<u8> for PreimageKeyType {
 /// |---------|-------------|
 /// | [0, 1)  | Type byte   |
 /// | [1, 32) | Data        |
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct PreimageKey {
     data: [u8; 31],


### PR DESCRIPTION
**Description**

We need to Serialize and Deserialize traits implemented on `PreimageKeys` to pass them into the zkVM. Adding a feature flag to the `preimage` crate to do that.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
