### PR TITLE
feat(client): Dynamic RollupConfig Loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
- "cfg-if",
  "op-alloy-consensus",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ name = "alloy-consensus"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-eips 0.1.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
@@ -51,13 +51,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#060de7871a76e99863917e62717c97423c37cadf"
+version = "0.1.1"
+source = "git+https://github.com/alloy-rs/alloy#fd6116eea4059ab9acf6c86dd5fc98ff75f8103d"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-eips 0.1.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-serde 0.1.1",
  "serde",
 ]
 
@@ -76,12 +76,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#060de7871a76e99863917e62717c97423c37cadf"
+version = "0.1.1"
+source = "git+https://github.com/alloy-rs/alloy#fd6116eea4059ab9acf6c86dd5fc98ff75f8103d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-serde 0.1.1",
  "c-kzg",
  "serde",
  "sha2",
@@ -94,6 +94,16 @@ source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
  "serde",
 ]
 
@@ -114,8 +124,8 @@ name = "alloy-network"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-types",
@@ -130,7 +140,7 @@ name = "alloy-node-bindings"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -167,7 +177,7 @@ name = "alloy-provider"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-eips 0.1.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -237,9 +247,9 @@ name = "alloy-rpc-types"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=cb95183#cb95183d477024b57b27336035d10403e8ba55b8"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-genesis",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
@@ -275,7 +285,17 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#060de7871a76e99863917e62717c97423c37cadf"
+source = "git+https://github.com/alloy-rs/alloy?rev=e3f2f07#e3f2f075a9e7ad9753a255dbe71dbad6a91ba96d"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.1"
+source = "git+https://github.com/alloy-rs/alloy#fd6116eea4059ab9acf6c86dd5fc98ff75f8103d"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1418,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "hyper"
@@ -1440,6 +1460,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1629,6 +1666,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,8 +1766,8 @@ dependencies = [
 name = "kona-client"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
@@ -1759,8 +1815,8 @@ dependencies = [
 name = "kona-derive"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-node-bindings",
  "alloy-primitives",
  "alloy-provider",
@@ -1795,8 +1851,8 @@ dependencies = [
 name = "kona-executor"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-primitives",
  "alloy-rlp",
  "anyhow",
@@ -1813,8 +1869,8 @@ dependencies = [
 name = "kona-host"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
@@ -1843,7 +1899,7 @@ dependencies = [
 name = "kona-mpt"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
@@ -1863,7 +1919,7 @@ dependencies = [
 name = "kona-plasma"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
  "alloy-primitives",
  "alloy-provider",
  "alloy-transport-http",
@@ -1898,16 +1954,18 @@ dependencies = [
 name = "kona-primitives"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
  "anyhow",
+ "cfg-if",
  "op-alloy-consensus",
  "serde",
  "serde_json",
  "superchain-primitives",
+ "superchain-registry",
 ]
 
 [[package]]
@@ -2169,13 +2227,13 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "op-alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/op-alloy?branch=refcell/re-exports#d581e8a58b57ed008d0fa4368dac324f9a71b304"
+source = "git+https://github.com/alloy-rs/op-alloy?branch=refcell/re-exports#01e94e6d4a13ba8a5ee58fbeca1e830edea4730a"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-consensus 0.1.1",
+ "alloy-eips 0.1.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-serde 0.1.1",
  "serde",
 ]
 
@@ -2526,9 +2584,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
@@ -2540,6 +2598,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2638,6 +2697,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2831,17 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rusty-fork"
@@ -2914,6 +3012,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,17 +3184,34 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "superchain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ethereum-optimism/superchain-registry?branch=main#645bb0a309970f3cc03ef6ff84670fc35917772a"
+source = "git+https://github.com/ethereum-optimism/superchain-registry?branch=refcell/rollup-config-map#7f9b6ba16f785f9a9a3304237e7d4374d5368284"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
- "alloy-genesis",
+ "alloy-consensus 0.1.0",
+ "alloy-eips 0.1.0",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cb95183)",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
  "hashbrown",
  "serde",
  "serde_repr",
+]
+
+[[package]]
+name = "superchain-registry"
+version = "0.1.0"
+source = "git+https://github.com/ethereum-optimism/superchain-registry?branch=refcell/rollup-config-map#7f9b6ba16f785f9a9a3304237e7d4374d5368284"
+dependencies = [
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=e3f2f07)",
+ "alloy-primitives",
+ "hashbrown",
+ "include_dir",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_yaml",
+ "superchain-primitives",
 ]
 
 [[package]]
@@ -3122,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -3271,6 +3399,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3463,10 +3602,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/bin/programs/client/Cargo.toml
+++ b/bin/programs/client/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-# workspace
+# Workspace
 cfg-if.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
@@ -21,15 +21,16 @@ spin.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 
-# local
+# Local
 kona-common = { path = "../../../crates/common", version = "0.0.1" }
 kona-common-proc = { path = "../../../crates/common-proc", version = "0.0.1" }
 kona-preimage = { path = "../../../crates/preimage", version = "0.0.1" }
-kona-primitives = { path = "../../../crates/primitives", version = "0.0.1" }
+kona-primitives = { path = "../../../crates/primitives", version = "0.0.1", default-features = false }
 kona-mpt = { path = "../../../crates/mpt", version = "0.0.1" }
 kona-derive = { path = "../../../crates/derive", default-features = false, version = "0.0.1" }
 kona-executor = { path = "../../../crates/executor", version = "0.0.1" }
 
+# `tracing-subscriber` feature
 tracing-subscriber = { version = "0.3.18", optional = true }
 
 [dev-dependencies]
@@ -37,6 +38,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.117"
 
 [features]
+serde = ["kona-primitives/serde"]
 tracing-subscriber = ["dep:tracing-subscriber"]
 
 [[bin]]

--- a/bin/programs/client/src/boot.rs
+++ b/bin/programs/client/src/boot.rs
@@ -4,7 +4,7 @@
 use alloy_primitives::{B256, U256};
 use anyhow::{anyhow, Result};
 use kona_preimage::{PreimageKey, PreimageOracleClient};
-use kona_primitives::{RollupConfig, OP_MAINNET_CONFIG};
+use kona_primitives::{get_rollup_config, RollupConfig};
 
 /// The local key ident for the L1 head hash.
 pub const L1_HEAD_KEY: U256 = U256::from_be_slice(&[1]);
@@ -89,16 +89,8 @@ impl BootInfo {
                 .try_into()
                 .map_err(|_| anyhow!("Failed to convert L2 chain ID to u64"))?,
         );
-        let rollup_config = rollup_config_from_chain_id(chain_id)?;
+        let rollup_config = get_rollup_config(chain_id)?;
 
         Ok(Self { l1_head, l2_output_root, l2_claim, l2_claim_block, chain_id, rollup_config })
-    }
-}
-
-/// Returns the rollup config for the given chain ID.
-fn rollup_config_from_chain_id(chain_id: u64) -> Result<RollupConfig> {
-    match chain_id {
-        10 => Ok(OP_MAINNET_CONFIG),
-        _ => anyhow::bail!("Unsupported chain ID: {}", chain_id),
     }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+# Workspace
 anyhow.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp = { workspace = true, features = ["derive"] }
@@ -16,18 +17,18 @@ alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-eips.workspace = true
 op-alloy-consensus.workspace = true
 
-# Superchain Registry
-superchain-primitives = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "main", default-features = false }
-
-# Alloy Types
+# External
+cfg-if = "1.0.0"
 alloy-sol-types = { version = "0.7.6", default-features = false }
+superchain-primitives = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "refcell/rollup-config-map", default-features = false }
 
 # `serde` feature dependencies
 serde = { version = "1.0.203", default-features = false, features = ["derive"], optional = true }
+superchain-registry = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "refcell/rollup-config-map", default-feature = false, optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.117", default-features = false }
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "superchain-primitives/serde"]
+serde = ["dep:serde", "dep:superchain-registry", "superchain-primitives/serde"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,13 +18,12 @@ alloy-eips.workspace = true
 op-alloy-consensus.workspace = true
 
 # External
-cfg-if = "1.0.0"
 alloy-sol-types = { version = "0.7.6", default-features = false }
 superchain-primitives = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "refcell/rollup-config-map", default-features = false }
 
 # `serde` feature dependencies
 serde = { version = "1.0.203", default-features = false, features = ["derive"], optional = true }
-superchain-registry = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "refcell/rollup-config-map", default-feature = false, optional = true }
+superchain-registry = { git = "https://github.com/ethereum-optimism/superchain-registry", branch = "refcell/rollup-config-map", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.117", default-features = false }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,11 +43,12 @@ pub use attributes::{L2AttributesWithParent, L2PayloadAttributes};
 
 /// Retrieves the [RollupConfig] for the given `chain_id`.
 pub fn get_rollup_config(chain_id: u64) -> anyhow::Result<RollupConfig> {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "serde")] {
-    superchain_registry::ROLLUP_CONFIGS.get(&chain_id).ok_or_else(|| anyhow::anyhow!("Unknown chain ID: {}", chain_id)).cloned()
-        } else {
-            kona_primitives::rollup_config_from_chain_id(chain_id)
-        }
+    if cfg!(feature = "serde") {
+        superchain_registry::ROLLUP_CONFIGS
+            .get(&chain_id)
+            .ok_or_else(|| anyhow::anyhow!("Unknown chain ID: {}", chain_id))
+            .cloned()
+    } else {
+        superchain_primitives::rollup_config_from_chain_id(chain_id)
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,6 +7,10 @@
 // Re-export superchain-primitives
 pub use superchain_primitives::*;
 
+// Re-export superchain bindings if the `serde` feature is enabled
+#[cfg(feature = "serde")]
+pub use superchain_registry::*;
+
 extern crate alloc;
 
 /// Re-export the [Withdrawal] type from the [alloy_eips] crate.
@@ -36,3 +40,14 @@ pub use payload::{
 
 pub mod attributes;
 pub use attributes::{L2AttributesWithParent, L2PayloadAttributes};
+
+/// Retrieves the [RollupConfig] for the given `chain_id`.
+pub fn get_rollup_config(chain_id: u64) -> anyhow::Result<RollupConfig> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "serde")] {
+    superchain_registry::ROLLUP_CONFIGS.get(&chain_id).ok_or_else(|| anyhow::anyhow!("Unknown chain ID: {}", chain_id)).cloned()
+        } else {
+            kona_primitives::rollup_config_from_chain_id(chain_id)
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Updates the client program to dynamically load the rollup config based on chain id using the `superchain-primitives` mapping if `serde` is not enabled, and the `superchain-bindings` dynamic mapping if `serde` is enabled.

**Metadata**

Fixes https://github.com/ethereum-optimism/kona/issues/261