### PR TITLE
fix(derive): Warnings with metrics macro

### DIFF
--- a/crates/derive/src/macros.rs
+++ b/crates/derive/src/macros.rs
@@ -6,8 +6,6 @@ macro_rules! timer {
     (START, $metric:ident, $labels:expr, $timer:ident) => {
         #[cfg(feature = "metrics")]
         let $timer = $crate::metrics::$metric.with_label_values($labels).start_timer();
-        #[cfg(not(feature = "metrics"))]
-        let $timer = ();
     };
     (DISCARD, $timer:ident) => {
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
## Overview

Fixes the compiler warnings for unused variables with the `timer!` macro in `kona-derive`.
