### PR TITLE
fix(examples): Graceful Payload Validation

### DIFF
--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -142,7 +142,7 @@ impl DerivationDriver {
                 }
             }
 
-            attributes = self.pipeline.next_attributes();
+            attributes = self.pipeline.next();
         }
 
         Ok(attributes.expect("Must be some"))

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -56,8 +56,13 @@ where
     S: NextAttributes + ResettableStage + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
+    /// Peeks at the next prepared [L2AttributesWithParent] from the pipeline.
+    fn peek(&self) -> Option<&L2AttributesWithParent> {
+        self.prepared.front()
+    }
+
     /// Returns the next prepared [L2AttributesWithParent] from the pipeline.
-    fn next_attributes(&mut self) -> Option<L2AttributesWithParent> {
+    fn next(&mut self) -> Option<L2AttributesWithParent> {
         self.prepared.pop_front()
     }
 

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -8,8 +8,11 @@ use kona_primitives::{BlockInfo, L2AttributesWithParent, L2BlockInfo};
 /// This trait defines the interface for interacting with the derivation pipeline.
 #[async_trait]
 pub trait Pipeline: OriginProvider {
+    /// Peeks at the next [L2AttributesWithParent] from the pipeline.
+    fn peek(&self) -> Option<&L2AttributesWithParent>;
+
     /// Returns the next [L2AttributesWithParent] from the pipeline.
-    fn next_attributes(&mut self) -> Option<L2AttributesWithParent>;
+    fn next(&mut self) -> Option<L2AttributesWithParent>;
 
     /// Resets the pipeline on the next [Pipeline::step] call.
     async fn reset(&mut self, origin: BlockInfo) -> anyhow::Result<()>;


### PR DESCRIPTION
**Description**

- Makes payload validation graceful - returning a `Result<bool>`.
- Rejiggers the pipeline to allow the consumer to peek at attributes for validation. This makes downstream validation easier such that if validation errors, no additional tracking needs to be done to re-try validation.