### PR TITLE
chore(derive): Remove noisy batch logs

### DIFF
--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -151,7 +151,7 @@ where
                     remaining.push(batch.clone());
                 }
                 BatchValidity::Drop => {
-                    warn!(target: "batch-queue", "Dropping batch: {:?}, parent: {}", batch.batch, parent.block_info);
+                    warn!(target: "batch-queue", "Dropping batch with parent: {}", parent.block_info);
                     continue;
                 }
                 BatchValidity::Accept => {
@@ -171,7 +171,7 @@ where
         self.batches = remaining;
 
         if let Some(nb) = next_batch {
-            info!(target: "batch-queue", "Next batch found: {:?}", nb.batch);
+            info!(target: "batch-queue", "Next batch found for timestamp {}", nb.batch.timestamp());
             return Ok(nb.batch);
         }
 


### PR DESCRIPTION
## Overview

Removes the noisy batch logs in `info!` / `warn!` log levels within the `BatchQueue`. These cause a significant slowdown due to having to `Debug` format the entire batch, which can be tens of megabytes large when decompressed.
