### PR TITLE
fix(derive): Prefix Metric Names

### DIFF
--- a/crates/derive/src/metrics.rs
+++ b/crates/derive/src/metrics.rs
@@ -16,40 +16,40 @@ const RESPONSE_TIME_CUSTOM_BUCKETS: &[f64; 18] = &[
 lazy_static! {
     /// Tracks the L1 origin for the L1 Traversal Stage.
     pub static ref ORIGIN_GAUGE: IntGauge = register_int_gauge!(
-        "origin_gauge",
+        "kona_derive_origin_gauge",
         "Tracks the L1 origin for the L1 Traversal Stage"
     ).expect("Origin Gauge failed to register");
 
     /// Tracks batch reader errors.
     pub static ref BATCH_READER_ERRORS: CounterVec = register_counter_vec!(
-        "batch_reader_errors",
+        "kona_derive_batch_reader_errors",
         "Number of batch reader errors",
         &["error"]
     ).expect("Batch Reader Errors failed to register");
 
     /// Tracks the compression ratio of batches.
     pub static ref BATCH_COMPRESSION_RATIO: IntGauge = register_int_gauge!(
-        "batch_compression_ratio",
+        "kona_derive_batch_compression_ratio",
         "Compression ratio of batches"
     ).expect("Batch Compression Ratio failed to register");
 
     /// Tracks the number of provider method calls.
     pub static ref PROVIDER_CALLS: CounterVec = register_counter_vec!(
-        "provider_calls",
+        "kona_derive_provider_calls",
         "Number of provider method calls",
         &["provider", "method"]
     ).expect("Provider Calls failed to register");
 
     /// Tracks the number of errors in provider methods.
     pub static ref PROVIDER_ERRORS: CounterVec = register_counter_vec!(
-        "provider_errors",
+        "kona_derive_provider_errors",
         "Number of provider errors",
         &["provider", "method", "error"]
     ).expect("Provider Errors failed to register");
 
     /// Tracks the time taken for provider methods.
     pub static ref PROVIDER_RESPONSE_TIME: HistogramVec = register_histogram_vec!(
-        "provider_response_time_seconds",
+        "kona_derive_provider_response_time_seconds",
         "Provider response times",
         &["provider", "method"],
         RESPONSE_TIME_CUSTOM_BUCKETS.to_vec()
@@ -58,7 +58,7 @@ lazy_static! {
 
     /// Tracks the time taken for stage advance methods.
     pub static ref STAGE_ADVANCE_RESPONSE_TIME: HistogramVec = register_histogram_vec!(
-        "stage_advance_response_time_seconds",
+        "kona_derive_stage_advance_response_time_seconds",
         "Stage advance response times",
         &["stage"],
         RESPONSE_TIME_CUSTOM_BUCKETS.to_vec()
@@ -66,7 +66,7 @@ lazy_static! {
 
     /// Tracks the number of derived frames.
     pub static ref DERIVED_FRAMES_COUNT: GaugeVec = {
-        let opts = opts!("derived_frames_count", "Number of derived frames");
+        let opts = opts!("kona_derive_derived_frames_count", "Number of derived frames");
         register_gauge_vec!(opts, &["status"]).expect("Derived Frames Count failed to register")
     };
 
@@ -74,7 +74,7 @@ lazy_static! {
     pub static ref CHANNEL_TIMEOUTS: Histogram = {
         let channel_timeout_buckets: [f64; 100] = core::array::from_fn(|i| (i * 10) as f64);
         register_histogram!(
-            "channel_timeouts",
+            "kona_derive_channel_timeouts",
             "Channel timeouts",
             channel_timeout_buckets.to_vec()
         ).expect("Failed to register histogram vec")

--- a/examples/trusted-sync/src/metrics.rs
+++ b/examples/trusted-sync/src/metrics.rs
@@ -10,19 +10,19 @@ use prometheus::{register_gauge_vec, register_int_counter};
 lazy_static! {
     /// Tracks the number of failed payload derivations.
     pub static ref FAILED_PAYLOAD_DERIVATION: IntCounter =
-        register_int_counter!("failed_payload_derivation", "Number of failed payload derivations")
+        register_int_counter!("trusted_sync_failed_payload_derivation", "Number of failed payload derivations")
             .expect("Failed to register failed payload derivation metric");
 
     /// Tracks the number of total payload attributes derived.
     pub static ref DERIVED_ATTRIBUTES_COUNT: IntCounter = register_int_counter!(
-        "derived_attributes_count",
+        "trusted_sync_derived_attributes_count",
         "Number of total payload attributes derived"
     )
     .expect("Failed to register derived attributes count metric");
 
     /// Tracks the pending L2 safe head.
     pub static ref SAFE_L2_HEAD: IntCounter =
-        register_int_counter!("safe_l2_head", "Pending L2 safe head").expect("Failed to register safe L2 head metric");
+        register_int_counter!("trusted_sync_safe_l2_head", "Pending L2 safe head").expect("Failed to register safe L2 head metric");
 
     /// Tracks the number of pipeline steps.
     pub static ref PIPELINE_STEPS: GaugeVec = {


### PR DESCRIPTION
**Description**

Prefix all metric names.
Metrics in `kona-derive` are prefixed with `kona_derive_*`.
Metrics in the `trusted-sync` binary are prefixed with `trusted_sync_*`.

This makes it easier to find metrics from the Grafana Metrics Explorer.