### PR TITLE
fix(derive): Pipeline Iterator

### DIFF
--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -50,6 +50,18 @@ where
     }
 }
 
+impl<S, P> Iterator for DerivationPipeline<S, P>
+where
+    S: NextAttributes + ResettableStage + OriginProvider + OriginAdvancer + Debug + Send + Sync,
+    P: L2ChainProvider + Send + Sync + Debug,
+{
+    type Item = L2AttributesWithParent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.prepared.pop_front()
+    }
+}
+
 #[async_trait]
 impl<S, P> Pipeline for DerivationPipeline<S, P>
 where
@@ -59,11 +71,6 @@ where
     /// Peeks at the next prepared [L2AttributesWithParent] from the pipeline.
     fn peek(&self) -> Option<&L2AttributesWithParent> {
         self.prepared.front()
-    }
-
-    /// Returns the next prepared [L2AttributesWithParent] from the pipeline.
-    fn next(&mut self) -> Option<L2AttributesWithParent> {
-        self.prepared.pop_front()
     }
 
     /// Resets the pipelien by calling the [`ResettableStage::reset`] method.

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -3,16 +3,14 @@
 use super::OriginProvider;
 use alloc::boxed::Box;
 use async_trait::async_trait;
+use core::iter::Iterator;
 use kona_primitives::{BlockInfo, L2AttributesWithParent, L2BlockInfo};
 
 /// This trait defines the interface for interacting with the derivation pipeline.
 #[async_trait]
-pub trait Pipeline: OriginProvider {
+pub trait Pipeline: OriginProvider + Iterator<Item = L2AttributesWithParent> {
     /// Peeks at the next [L2AttributesWithParent] from the pipeline.
     fn peek(&self) -> Option<&L2AttributesWithParent>;
-
-    /// Returns the next [L2AttributesWithParent] from the pipeline.
-    fn next(&mut self) -> Option<L2AttributesWithParent>;
 
     /// Resets the pipeline on the next [Pipeline::step] call.
     async fn reset(&mut self, origin: BlockInfo) -> anyhow::Result<()>;


### PR DESCRIPTION
**Description**

Binds the `Pipeline` trait to be an `Iterator<Item = L2AttributesWithParent>`.

This replaces the custom `next()` method definition with the [`core::iter::Iterator`](https://doc.rust-lang.org/stable/core/iter/trait.Iterator.html) trait that allows for greater fluency.