### PR TITLE
fix(examples): Dockerfile Fixes

### DIFF
--- a/examples/trusted-sync/run.sh
+++ b/examples/trusted-sync/run.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/bash
 
+START="${START_L2_BLOCK:-0}"
+METRICS="${METRICS_URL:-127.0.0.1:9000}"
+
 /usr/local/bin/trusted-sync \
   --l1-rpc-url $L1_RPC_URL \
   --l2-rpc-url $L2_RPC_URL \
   --beacon-url $BEACON_URL \
-  --loki-url $LOKI_URL \
-  --start-l2-block $START_L2_BLOCK \
-  --metrics-server-addr $METRICS_SERVER_ADDR \
-  --metrics-server-port $METRICS_SERVER_PORT \
+  --metrics-url $METRICS \
+  --start-l2-block $START \
   -vvv

--- a/examples/trusted-sync/src/cli.rs
+++ b/examples/trusted-sync/src/cli.rs
@@ -30,27 +30,24 @@ pub struct Cli {
     /// The l2 block to start from.
     #[clap(long, short, help = "Starting l2 block, defaults to chain genesis if none specified")]
     pub start_l2_block: Option<u64>,
-    /// The address of the metrics server.
+    /// The url for metrics.
     #[clap(long, help = "Address of the metrics server")]
-    pub metrics_server_addr: Option<String>,
-    /// The metrics server port.
-    #[clap(long, help = "Port of the metrics server")]
-    pub metrics_server_port: Option<u16>,
+    pub metrics_url: Option<String>,
     /// The Loki Url endpoint.
     #[clap(long, help = "Url to post Loki logs")]
     pub loki_url: Option<String>,
+    /// Whether to enable Loki Metrics.
+    #[clap(long, help = "Enable Loki metrics")]
+    pub loki_metrics: bool,
 }
 
 impl Cli {
     /// Returns the full metrics server address string.
     pub fn metrics_server_addr(&self) -> String {
-        format!(
-            "{}:{}",
-            self.metrics_server_addr
-                .clone()
-                .unwrap_or_else(|| DEFAULT_METRICS_SERVER_ADDR.to_string()),
-            self.metrics_server_port.unwrap_or(DEFAULT_METRICS_SERVER_PORT)
-        )
+        if let Some(url) = self.metrics_url.clone() {
+            return url;
+        }
+        format!("{}:{}", DEFAULT_METRICS_SERVER_ADDR, DEFAULT_METRICS_SERVER_PORT)
     }
 
     /// Returns the full loki server address.

--- a/examples/trusted-sync/src/telemetry.rs
+++ b/examples/trusted-sync/src/telemetry.rs
@@ -3,7 +3,21 @@ use reqwest::Url;
 use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, prelude::*};
 
-pub async fn init(v: u8, addr: Url) -> Result<()> {
+/// Initializes the tracing subscriber
+pub fn init(v: u8) -> Result<()> {
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(match v {
+            0 => Level::ERROR,
+            1 => Level::WARN,
+            2 => Level::INFO,
+            3 => Level::DEBUG,
+            _ => Level::TRACE,
+        })
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).map_err(|e| anyhow!(e))
+}
+
+pub fn init_with_loki(v: u8, addr: Url) -> Result<()> {
     let (loki_layer, task) = tracing_loki::builder()
         .label("environment", "production")
         .map_err(|e| anyhow!(e))?

--- a/justfile
+++ b/justfile
@@ -99,8 +99,16 @@ docker-run-ts:
     -e L1_RPC_URL=$L1_RPC_URL \
     -e L2_RPC_URL=$L2_RPC_URL \
     -e BEACON_URL=$BEACON_URL \
-    -e LOKI_URL=$LOKI_URL \
-    -e START_L2_BLOCK=$START_L2_BLOCK \
-    -e METRICS_SERVER_ADDR=$METRICS_SERVER_ADDR \
-    -e METRICS_SERVER_PORT=$METRICS_SERVER_PORT \
     trusted-sync
+
+# Run the `trusted-sync` docker container with Loki logging
+docker-run-ts-with-loki:
+  docker run -it \
+    -e L1_RPC_URL=$L1_RPC_URL \
+    -e L2_RPC_URL=$L2_RPC_URL \
+    -e BEACON_URL=$BEACON_URL \
+    -e LOKI_URL=$LOKI_URL \
+    -e METRICS_URL=$METRICS_URL \
+    -e START_L2_BLOCK=$START_L2_BLOCK \
+    trusted-sync
+


### PR DESCRIPTION
**Description**

Cleans up the `trusted-sync` binary for infra deployment.

- Makes loki logging optional.
- Gracefully handles missing start block and metrics url.