### PR TITLE
fix(examples): Start N Blocks Back from Tip

### DIFF
--- a/crates/derive/src/online/alloy_providers.rs
+++ b/crates/derive/src/online/alloy_providers.rs
@@ -287,6 +287,19 @@ impl AlloyL2ChainProvider {
         u64::from_str_radix(&chain_id, 16).map_err(|e| anyhow!(e))
     }
 
+    /// Returns the latest L2 block number.
+    pub async fn latest_block_number(&mut self) -> Result<u64> {
+        let b: TransportResult<alloc::string::String> =
+            self.inner.raw_request("eth_blockNumber".into(), ()).await;
+        match b {
+            Ok(s) => {
+                let s = alloc::string::String::from(s.trim_start_matches("0x"));
+                u64::from_str_radix(&s, 16).map_err(|e| anyhow!(e))
+            }
+            Err(e) => Err(anyhow!(e)),
+        }
+    }
+
     /// Creates a new [AlloyL2ChainProvider] from the provided [reqwest::Url].
     pub fn new_http(url: reqwest::Url, rollup_config: Arc<RollupConfig>) -> Self {
         let inner = ReqwestProvider::new_http(url);

--- a/examples/trusted-sync/run.sh
+++ b/examples/trusted-sync/run.sh
@@ -3,10 +3,21 @@
 START="${START_L2_BLOCK:-0}"
 METRICS="${METRICS_URL:-127.0.0.1:9000}"
 
-/usr/local/bin/trusted-sync \
-  --l1-rpc-url $L1_RPC_URL \
-  --l2-rpc-url $L2_RPC_URL \
-  --beacon-url $BEACON_URL \
-  --metrics-url $METRICS \
-  --start-l2-block $START \
-  -vvv
+# If the `START_BLOCKS_FROM_TIP` environment variable is set, we will start syncing from the tip of the chain.
+if [ -n "$START_BLOCKS_FROM_TIP" ]; then
+  /usr/local/bin/trusted-sync \
+    --l1-rpc-url $L1_RPC_URL \
+    --l2-rpc-url $L2_RPC_URL \
+    --beacon-url $BEACON_URL \
+    --metrics-url $METRICS \
+    --start-blocks-from-tip $START_BLOCKS_FROM_TIP \
+    -vvv
+else
+  /usr/local/bin/trusted-sync \
+    --l1-rpc-url $L1_RPC_URL \
+    --l2-rpc-url $L2_RPC_URL \
+    --beacon-url $BEACON_URL \
+    --metrics-url $METRICS \
+    --start-l2-block $START \
+    -vvv
+fi

--- a/examples/trusted-sync/src/cli.rs
+++ b/examples/trusted-sync/src/cli.rs
@@ -39,6 +39,9 @@ pub struct Cli {
     /// Whether to enable Loki Metrics.
     #[clap(long, help = "Enable Loki metrics")]
     pub loki_metrics: bool,
+    /// Start blocks from tip.
+    #[clap(long, help = "Number of blocks prior to tip to start from")]
+    pub start_blocks_from_tip: Option<u64>,
 }
 
 impl Cli {

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -58,8 +58,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     // If the start block from tip cli flag is specified, find the latest l2 block number
     // and subtract the specified number of blocks to get the start block number.
     if let Some(blocks) = cli.start_blocks_from_tip {
-        let latest = l2_provider.latest_block_number().await?;
-        start = latest.saturating_sub(blocks);
+        start = l2_provider.latest_block_number().await?.saturating_sub(blocks);
         info!(target: LOG_TARGET, "Starting {} blocks from tip at L2 block number: {}", blocks, start);
     }
 

--- a/justfile
+++ b/justfile
@@ -99,6 +99,9 @@ docker-run-ts:
     -e L1_RPC_URL=$L1_RPC_URL \
     -e L2_RPC_URL=$L2_RPC_URL \
     -e BEACON_URL=$BEACON_URL \
+    -e METRICS_URL=$METRICS_URL \
+    -e START_L2_BLOCK=$START_L2_BLOCK \
+    -e START_BLOCKS_FROM_TIP=$START_BLOCKS_FROM_TIP \
     trusted-sync
 
 # Run the `trusted-sync` docker container with Loki logging
@@ -110,6 +113,7 @@ docker-run-ts-with-loki:
     -e LOKI_URL=$LOKI_URL \
     -e METRICS_URL=$METRICS_URL \
     -e START_L2_BLOCK=$START_L2_BLOCK \
+    -e START_BLOCKS_FROM_TIP=$START_BLOCKS_FROM_TIP \
     trusted-sync
 
 # Build the `kona-client` prestate artifacts for the latest release.


### PR DESCRIPTION
**Description**

Adds a cli flag that allows `trusted-sync` to start N blocks back from tip.

Avoids needing to have a blob archiver by starting <18 days in the past.