### PR TITLE
chore(preimage): Remove dynamic dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,6 +2030,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-transport-http",
  "anyhow",
+ "async-trait",
  "clap",
  "command-fds",
  "futures",

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -17,6 +17,7 @@ revm = { workspace = true, features = ["std", "c-kzg", "secp256k1", "portable", 
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
+async-trait.workspace = true
 
 # local
 kona-client = { path = "../client", version = "0.1.0" }

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -29,6 +29,7 @@ use types::NativePipeFiles;
 mod cli;
 mod fetcher;
 mod kv;
+mod preimage;
 mod server;
 mod types;
 mod util;

--- a/bin/host/src/preimage.rs
+++ b/bin/host/src/preimage.rs
@@ -1,0 +1,106 @@
+//! Contains the implementations of the [HintRouter] and [PreimageFetcher] traits.]
+
+use crate::{fetcher::Fetcher, kv::KeyValueStore};
+use anyhow::Result;
+use async_trait::async_trait;
+use kona_preimage::{HintRouter, PreimageFetcher, PreimageKey};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// A [Fetcher]-backed implementation of the [PreimageFetcher] trait.
+pub struct OnlinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    inner: Arc<RwLock<Fetcher<KV>>>,
+}
+
+#[async_trait]
+impl<KV> PreimageFetcher for OnlinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + Send + Sync + ?Sized,
+{
+    async fn get_preimage(&self, key: PreimageKey) -> Result<Vec<u8>> {
+        let fetcher = self.inner.read().await;
+        fetcher.get_preimage(key.into()).await
+    }
+}
+
+impl<KV> OnlinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    /// Create a new [OnlinePreimageFetcher] from the given [Fetcher].
+    pub fn new(fetcher: Arc<RwLock<Fetcher<KV>>>) -> Self {
+        Self { inner: fetcher }
+    }
+}
+
+/// A [KeyValueStore]-backed implementation of the [PreimageFetcher] trait.
+pub struct OfflinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    inner: Arc<RwLock<KV>>,
+}
+
+#[async_trait]
+impl<KV> PreimageFetcher for OfflinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + Send + Sync + ?Sized,
+{
+    async fn get_preimage(&self, key: PreimageKey) -> Result<Vec<u8>> {
+        let kv_store = self.inner.read().await;
+        kv_store.get(key.into()).ok_or_else(|| anyhow::anyhow!("Key not found"))
+    }
+}
+
+impl<KV> OfflinePreimageFetcher<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    /// Create a new [OfflinePreimageFetcher] from the given [KeyValueStore].
+    pub fn new(kv_store: Arc<RwLock<KV>>) -> Self {
+        Self { inner: kv_store }
+    }
+}
+
+/// A [Fetcher]-backed implementation of the [HintRouter] trait.
+pub struct OnlineHintRouter<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    inner: Arc<RwLock<Fetcher<KV>>>,
+}
+
+#[async_trait]
+impl<KV> HintRouter for OnlineHintRouter<KV>
+where
+    KV: KeyValueStore + Send + Sync + ?Sized,
+{
+    async fn route_hint(&self, hint: String) -> Result<()> {
+        let mut fetcher = self.inner.write().await;
+        fetcher.hint(&hint);
+        Ok(())
+    }
+}
+
+impl<KV> OnlineHintRouter<KV>
+where
+    KV: KeyValueStore + ?Sized,
+{
+    /// Create a new [OnlineHintRouter] from the given [Fetcher].
+    pub fn new(fetcher: Arc<RwLock<Fetcher<KV>>>) -> Self {
+        Self { inner: fetcher }
+    }
+}
+
+/// An [OfflineHintRouter] is a [HintRouter] that does nothing.
+pub struct OfflineHintRouter;
+
+#[async_trait]
+impl HintRouter for OfflineHintRouter {
+    async fn route_hint(&self, _hint: String) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/preimage/src/lib.rs
+++ b/crates/preimage/src/lib.rs
@@ -19,4 +19,7 @@ mod pipe;
 pub use pipe::PipeHandle;
 
 mod traits;
-pub use traits::{HintReaderServer, HintWriterClient, PreimageOracleClient, PreimageOracleServer};
+pub use traits::{
+    HintReaderServer, HintRouter, HintWriterClient, PreimageFetcher, PreimageOracleClient,
+    PreimageOracleServer,
+};

--- a/crates/preimage/src/traits.rs
+++ b/crates/preimage/src/traits.rs
@@ -2,7 +2,6 @@ use crate::PreimageKey;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use anyhow::Result;
 use async_trait::async_trait;
-use core::future::Future;
 
 /// A [PreimageOracleClient] is a high-level interface to read data from the host, keyed by a
 /// [PreimageKey].
@@ -47,10 +46,9 @@ pub trait PreimageOracleServer {
     /// # Returns
     /// - `Ok(())` if the data was successfully written into the client pipe.
     /// - `Err(_)` if the data could not be written to the client.
-    async fn next_preimage_request<F, Fut>(&self, get_preimage: F) -> Result<()>
+    async fn next_preimage_request<F>(&self, get_preimage: &F) -> Result<()>
     where
-        F: FnMut(PreimageKey) -> Fut + Send,
-        Fut: Future<Output = Result<Vec<u8>>> + Send;
+        F: PreimageFetcher + Send + Sync;
 }
 
 /// A [HintReaderServer] is a high-level interface to read preimage hints from the
@@ -63,8 +61,35 @@ pub trait HintReaderServer {
     /// - `Ok(())` if the hint was received and the client was notified of the host's
     ///   acknowledgement.
     /// - `Err(_)` if the hint was not received correctly.
-    async fn next_hint<F, Fut>(&self, route_hint: F) -> Result<()>
+    async fn next_hint<R>(&self, route_hint: &R) -> Result<()>
     where
-        F: FnMut(String) -> Fut + Send,
-        Fut: Future<Output = Result<()>> + Send;
+        R: HintRouter + Send + Sync;
+}
+
+/// A [HintRouter] is a high-level interface to route hints to the appropriate handler.
+#[async_trait]
+pub trait HintRouter {
+    /// Routes a hint to the appropriate handler.
+    ///
+    /// # Arguments
+    /// - `hint`: The hint to route.
+    ///
+    /// # Returns
+    /// - `Ok(())` if the hint was successfully routed.
+    /// - `Err(_)` if the hint could not be routed.
+    async fn route_hint(&self, hint: String) -> Result<()>;
+}
+
+/// A [PreimageFetcher] is a high-level interface to fetch preimages during preimage requests.
+#[async_trait]
+pub trait PreimageFetcher {
+    /// Get the preimage corresponding to the given key.
+    ///
+    /// # Arguments
+    /// - `key`: The key to fetch the preimage for.
+    ///
+    /// # Returns
+    /// - `Ok(Vec<u8>)` if the preimage was successfully fetched.
+    /// - `Err(_)` if the preimage could not be fetched.
+    async fn get_preimage(&self, key: PreimageKey) -> Result<Vec<u8>>;
 }


### PR DESCRIPTION
## Overview

Removes dynamic dispatch from the host-oriented types in `kona-preimage`, in favor of a more flexible and readable alternative.
