### PR TITLE
chore(host): Make `exec` flag optional

### DIFF
--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -60,7 +60,6 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
     --l2-node-address $L2_NODE_ADDRESS \
     --server \
     --data-dir ./data \
-    --exec "" \
     {{verbosity}}
 
 # Run the client program natively with the host program attached.

--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -55,7 +55,7 @@ pub struct HostCli {
     /// Run the specified client program as a separate process detached from the host. Default is
     /// to run the client program in the host process.
     #[clap(long)]
-    pub exec: String,
+    pub exec: Option<String>,
     /// Run in pre-image server mode without executing any client program. Defaults to `false`.
     #[clap(long)]
     pub server: bool,

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -184,7 +184,8 @@ where
 async fn start_native_client_program(cfg: HostCli, files: NativePipeFiles) -> Result<()> {
     // Map the file descriptors to the standard streams and the preimage oracle and hint
     // reader's special file descriptors.
-    let mut command = Command::new(cfg.exec);
+    let mut command =
+        Command::new(cfg.exec.ok_or_else(|| anyhow!("No client program binary path specified."))?);
     command
         .fd_mappings(vec![
             FdMapping { parent_fd: stdin().as_fd().try_clone_to_owned().unwrap(), child_fd: 0 },


### PR DESCRIPTION
## Overview

Makes the `exec` flag optional in the host binary so that users may omit it when executing in `server` mode.
