### PR TITLE
feat(client, preimage, common): no-io flag

### DIFF
--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1.0.117"
 
 [features]
 tracing-subscriber = ["dep:tracing-subscriber"]
+no-io = ["kona-common/no-io", "kona-preimage/no-io"]
 
 [[bin]]
 name = "kona"

--- a/bin/client/src/l2/mod.rs
+++ b/bin/client/src/l2/mod.rs
@@ -6,5 +6,7 @@ pub use trie_hinter::TrieDBHintWriter;
 mod chain_provider;
 pub use chain_provider::OracleL2ChainProvider;
 
+#[cfg(not(feature = "no-io"))]
 mod precompiles;
+#[cfg(not(feature = "no-io"))]
 pub use precompiles::FPVMPrecompileOverride;

--- a/bin/client/src/lib.rs
+++ b/bin/client/src/lib.rs
@@ -13,7 +13,9 @@ pub mod l2;
 pub mod hint;
 pub use hint::HintType;
 
+#[cfg(not(feature = "no-io"))]
 mod comms;
+#[cfg(not(feature = "no-io"))]
 pub use comms::{CachingOracle, HINT_WRITER, ORACLE_READER};
 
 mod boot;

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,3 +16,6 @@ spin.workspace = true
 
 # external
 linked_list_allocator = "0.10.5"
+
+[features]
+no-io = []

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate alloc;
 
+#[cfg(not(feature = "no-io"))]
 pub mod io;
 
 pub mod malloc;

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 # local
 kona-common = { path = "../common", version = "0.0.2" }
 
+# external
 serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -28,3 +29,4 @@ tempfile = "3.10.1"
 [features]
 default = []
 serde = ["dep:serde"]
+no-io = ["kona-common/no-io"]

--- a/crates/preimage/src/lib.rs
+++ b/crates/preimage/src/lib.rs
@@ -9,17 +9,21 @@ extern crate alloc;
 mod key;
 pub use key::{PreimageKey, PreimageKeyType};
 
-mod oracle;
-pub use oracle::{OracleReader, OracleServer};
-
-mod hint;
-pub use hint::{HintReader, HintWriter};
-
-mod pipe;
-pub use pipe::PipeHandle;
-
 mod traits;
 pub use traits::{
     HintReaderServer, HintRouter, HintWriterClient, PreimageFetcher, PreimageOracleClient,
     PreimageOracleServer,
 };
+
+cfg_if::cfg_if! {
+    if #[cfg(not(feature = "no-io"))] {
+        mod oracle;
+        pub use oracle::{OracleReader, OracleServer};
+
+        mod hint;
+        pub use hint::{HintReader, HintWriter};
+
+        mod pipe;
+        pub use pipe::PipeHandle;
+    }
+}


### PR DESCRIPTION
**Description**

The `kona-common` crate determines which ClientIO to use based on the compilation environment. This crate is inherited by `kona-client` and `kona-preimage`, so in the case that any of these crates are imported, we try to compile ClientIO.

In the case that we aren't compiling to MIPS or RISCV64, we fallback to NativeIO, which fails in the ZKVM.

In the ZKVM, we don't use IO at all, so to avoid this issue we simply add a `no-io` feature flag to the 3 crates that avoids compiling anything that touches IO when called in this context. 

Then, in our downstream program, we set this flag depending on whether or not we are in the ZKVM context.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
