### PR TITLE
feat(host): kzg proof for blobs

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -219,6 +219,19 @@ where
                         sidecar.blob[(i as usize) << 5..(i as usize + 1) << 5].to_vec(),
                     );
                 }
+
+                // Write the KZG Proof as the 4096th element.
+                blob_key[72..].copy_from_slice((FIELD_ELEMENTS_PER_BLOB).to_be_bytes().as_ref());
+                let blob_key_hash = keccak256(blob_key.as_ref());
+
+                kv_write_lock.set(
+                    PreimageKey::new(*blob_key_hash, PreimageKeyType::Keccak256).into(),
+                    blob_key.into(),
+                );
+                kv_write_lock.set(
+                    PreimageKey::new(*blob_key_hash, PreimageKeyType::Blob).into(),
+                    sidecar.kzg_proof.to_vec(),
+                );
             }
             HintType::L1Precompile => {
                 // Validate the hint data length.


### PR DESCRIPTION
**Description**

Currently, when the fetcher gathers blob data, it saves the preimages for each element in the blob, but does not save the KZG proof (because it is not needed in FPVM context). However, in the ZKVM context, we need this information.

This PR creates a short term workaround to save the kzg proof as a psuedo element 4096 in the Blob type (since the blob only uses elements 0 to 4095 inclusive).

For a longer term fix, I've opened this ticket for a feature to override fetcher implementations: https://github.com/ethereum-optimism/kona/issues/369

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A