### PR TITLE
chore(examples): Log Payload Attributes on Error

### DIFF
--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -133,9 +133,9 @@ async fn sync(cli: cli::Cli) -> Result<()> {
         // Peek at the next prepared attributes and validate them.
         if let Some(attributes) = pipeline.peek() {
             match validator.validate(attributes).await {
-                Ok(true) => info!(target: LOG_TARGET, "Validated payload attributes"),
-                Ok(false) => {
-                    error!(target: LOG_TARGET, "Failed payload validation: {}", attributes.parent.block_info.hash);
+                Ok((true, _)) => info!(target: LOG_TARGET, "Validated payload attributes"),
+                Ok((false, expected)) => {
+                    error!(target: LOG_TARGET, "Failed payload validation. Derived payload attributes: {:?}, Expected: {:?}", attributes, expected);
                     metrics::FAILED_PAYLOAD_DERIVATION.inc();
                     let _ = pipeline.next(); // Take the attributes and continue
                     continue;

--- a/examples/trusted-sync/src/validation.rs
+++ b/examples/trusted-sync/src/validation.rs
@@ -80,11 +80,14 @@ impl OnlineValidator {
     }
 
     /// Validates the given [`L2AttributesWithParent`].
-    pub async fn validate(&self, attributes: &L2AttributesWithParent) -> Result<bool> {
+    pub async fn validate(
+        &self,
+        attributes: &L2AttributesWithParent,
+    ) -> Result<(bool, L2PayloadAttributes)> {
         let expected = attributes.parent.block_info.number + 1;
         let tag = BlockNumberOrTag::from(expected);
         match self.get_payload(tag).await {
-            Ok(payload) => Ok(attributes.attributes == payload),
+            Ok(payload) => Ok((attributes.attributes == payload, payload)),
             Err(e) => {
                 error!(target: "validation", "Failed to fetch payload for block {}: {:?}", expected, e);
                 Err(e)


### PR DESCRIPTION
**Description**

Logs derived and expected payload attributes on error to make investigation easier in the runbook for invalid derived payload attributes.