### PR TITLE
fix(examples): Reduce Origin Advance to Warn

### DIFF
--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -122,7 +122,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
             }
             StepResult::OriginAdvanceErr(e) => {
                 metrics::PIPELINE_STEPS.with_label_values(&["origin_advance_failure"]).inc();
-                warn!(target: "loop", "Error advancing origin: {:?}", e);
+                warn!(target: "loop", "Could not advance origin: {:?}", e);
             }
             StepResult::StepFailed(e) => {
                 metrics::PIPELINE_STEPS.with_label_values(&["failure"]).inc();

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use kona_derive::online::*;
 use std::sync::Arc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 mod cli;
 mod metrics;
@@ -122,7 +122,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
             }
             StepResult::OriginAdvanceErr(e) => {
                 metrics::PIPELINE_STEPS.with_label_values(&["origin_advance_failure"]).inc();
-                error!(target: "loop", "Error advancing origin: {:?}", e);
+                warn!(target: "loop", "Error advancing origin: {:?}", e);
             }
             StepResult::StepFailed(e) => {
                 metrics::PIPELINE_STEPS.with_label_values(&["failure"]).inc();


### PR DESCRIPTION
**Description**

Reduces the origin advance error to warning.

If the next block isn't available causing an intended block fetch failure, this will error which happens often.

We should also work in some backoffs to the providers, especially for frequently repeated method calls like origin advancing.