### PR TITLE
fix(examples): L2 Safe Head Tracking

### DIFF
--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use kona_derive::online::*;
 use std::sync::Arc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 mod cli;
 mod metrics;
@@ -79,7 +79,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
         .l2_block_info_by_number(start)
         .await
         .expect("Failed to fetch genesis L2 block info for pipeline cursor");
-    metrics::SAFE_L2_HEAD.inc_by(cursor.block_info.number);
+    metrics::SAFE_L2_HEAD.set(cursor.block_info.number as i64);
     let tip = l1_provider
         .block_info_by_number(cursor.l1_origin.number)
         .await
@@ -94,13 +94,19 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     // Continuously step on the pipeline and validate payloads.
     let mut advance_cursor_flag = false;
     loop {
-        info!(target: LOG_TARGET, "Validated payload attributes number {}", metrics::DERIVED_ATTRIBUTES_COUNT.get());
-        info!(target: LOG_TARGET, "Pending l2 safe head num: {}", cursor.block_info.number);
+        // Update the reference l2 head.
+        match l2_provider.latest_block_number().await {
+            Ok(latest) => {
+                metrics::REFERENCE_L2_HEAD.set(latest as i64);
+            }
+            Err(e) => {
+                warn!(target: LOG_TARGET, "Failed to fetch latest reference l2 safe head: {:?}", e);
+            }
+        }
         if advance_cursor_flag {
             match l2_provider.l2_block_info_by_number(cursor.block_info.number + 1).await {
                 Ok(bi) => {
                     cursor = bi;
-                    metrics::SAFE_L2_HEAD.inc();
                     advance_cursor_flag = false;
                 }
                 Err(e) => {
@@ -111,6 +117,8 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                 }
             }
         }
+        info!(target: LOG_TARGET, "Validated payload attributes number {}", metrics::DERIVED_ATTRIBUTES_COUNT.get());
+        info!(target: LOG_TARGET, "Pending l2 safe head num: {}", cursor.block_info.number);
         match pipeline.step(cursor).await {
             StepResult::PreparedAttributes => {
                 metrics::PIPELINE_STEPS.with_label_values(&["success"]).inc();
@@ -161,11 +169,13 @@ async fn sync(cli: cli::Cli) -> Result<()> {
 
         // If we validated payload attributes, we should advance the cursor.
         advance_cursor_flag = true;
+        let derived = attributes.parent.block_info.number as i64 + 1;
+        metrics::SAFE_L2_HEAD.set(derived);
         metrics::DERIVED_ATTRIBUTES_COUNT.inc();
         println!(
             "Validated Payload Attributes {} [L2 Block Num: {}] [L2 Timestamp: {}] [L1 Origin Block Num: {}]",
             metrics::DERIVED_ATTRIBUTES_COUNT.get(),
-            attributes.parent.block_info.number + 1,
+            derived,
             attributes.attributes.timestamp,
             pipeline.origin().unwrap().number,
         );

--- a/examples/trusted-sync/src/metrics.rs
+++ b/examples/trusted-sync/src/metrics.rs
@@ -2,10 +2,10 @@
 
 use actix_web::{get, App, HttpServer, Responder};
 use anyhow::Result;
-use prometheus::{self, opts, Encoder, GaugeVec, IntCounter, TextEncoder};
+use prometheus::{self, opts, Encoder, GaugeVec, IntCounter, IntGauge, TextEncoder};
 
 use lazy_static::lazy_static;
-use prometheus::{register_gauge_vec, register_int_counter};
+use prometheus::{register_gauge_vec, register_int_counter, register_int_gauge};
 
 lazy_static! {
     /// Tracks the starting L2 block number.
@@ -37,8 +37,12 @@ lazy_static! {
     .expect("Failed to register derived attributes count metric");
 
     /// Tracks the pending L2 safe head.
-    pub static ref SAFE_L2_HEAD: IntCounter =
-        register_int_counter!("trusted_sync_safe_l2_head", "Pending L2 safe head").expect("Failed to register safe L2 head metric");
+    pub static ref SAFE_L2_HEAD: IntGauge =
+        register_int_gauge!("trusted_sync_safe_l2_head", "Pending L2 safe head").expect("Failed to register safe L2 head metric");
+
+    /// Tracks the reference l2 head.
+    pub static ref REFERENCE_L2_HEAD: IntGauge =
+        register_int_gauge!("trusted_sync_reference_l2_head", "Reference L2 head").expect("Failed to register reference L2 head metric");
 
     /// Tracks the number of pipeline steps.
     pub static ref PIPELINE_STEPS: GaugeVec = {


### PR DESCRIPTION
**Description**

Fixes the l2 safe head to increment after payload attributes are derived.

Adds a reference l2 safe head tracker for drift alerting.