### PR TITLE
feat: add zkvm target for io

### DIFF
--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -12,6 +12,9 @@ cfg_if! {
     } else if #[cfg(target_arch = "riscv64")] {
         #[doc = "Concrete implementation of the [BasicKernelInterface] trait for the `riscv64` target architecture."]
         pub type ClientIO = crate::asterisc::io::AsteriscIO;
+    } else if #[cfg(target_os = "zkvm")] {
+        #[doc = "Concrete implementation of the [BasicKernelInterface] trait for the `SP1` target architecture."]
+        pub type ClientIO = crate::zkvm::io::ZkvmIO;
     } else {
         #[doc = "Concrete implementation of the [BasicKernelInterface] trait for the `native` target architecture."]
         pub type ClientIO = native_io::NativeIO;
@@ -54,7 +57,7 @@ pub fn exit(code: usize) -> ! {
     ClientIO::exit(code)
 }
 
-#[cfg(not(any(target_arch = "mips", target_arch = "riscv64")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "riscv64", target_os = "zkvm")))]
 mod native_io {
     extern crate std;
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -25,3 +25,6 @@ pub(crate) mod cannon;
 
 #[cfg(target_arch = "riscv64")]
 pub(crate) mod asterisc;
+
+#[cfg(target_os = "zkvm")]
+pub(crate) mod zkvm;

--- a/crates/common/src/zkvm/io.rs
+++ b/crates/common/src/zkvm/io.rs
@@ -1,0 +1,21 @@
+use crate::{BasicKernelInterface, FileDescriptor};
+use anyhow::Result;
+
+/// Concrete implementation of the [`KernelIO`] trait for the `SP1` target architecture.
+#[derive(Debug)]
+pub struct ZkvmIO;
+
+impl BasicKernelInterface for ZkvmIO {
+    fn write(_fd: FileDescriptor, _buf: &[u8]) -> Result<usize> {
+        unimplemented!();
+    }
+
+
+    fn read(_fd: FileDescriptor, _buf: &mut [u8]) -> Result<usize> {
+        unimplemented!();
+    }
+
+    fn exit(_code: usize) -> ! {
+        unimplemented!();
+    }
+}

--- a/crates/common/src/zkvm/io.rs
+++ b/crates/common/src/zkvm/io.rs
@@ -10,7 +10,6 @@ impl BasicKernelInterface for ZkvmIO {
         unimplemented!();
     }
 
-
     fn read(_fd: FileDescriptor, _buf: &mut [u8]) -> Result<usize> {
         unimplemented!();
     }

--- a/crates/common/src/zkvm/mod.rs
+++ b/crates/common/src/zkvm/mod.rs
@@ -1,0 +1,3 @@
+//! This module contains raw syscall bindings for the `ZKVM` compilation context.
+
+pub(crate) mod io;


### PR DESCRIPTION
**Description**

As an alternative to #368, this PR involves adding a simple alternative IO target to `kona-common`, which is currently a no-op but might later be used for more advanced cycle tracking, etc.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
