### PR TITLE
fix(mpt): hint `TrieNode` in `insert`

### DIFF
--- a/crates/mpt/benches/trie_node.rs
+++ b/crates/mpt/benches/trie_node.rs
@@ -20,7 +20,8 @@ fn trie(c: &mut Criterion) {
         b.iter(|| {
             let mut trie = TrieNode::Empty;
             for key in &keys {
-                trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+                trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter)
+                    .unwrap();
             }
         });
     });
@@ -32,7 +33,8 @@ fn trie(c: &mut Criterion) {
         b.iter(|| {
             let mut trie = TrieNode::Empty;
             for key in &keys {
-                trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+                trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter)
+                    .unwrap();
             }
         });
     });
@@ -46,7 +48,7 @@ fn trie(c: &mut Criterion) {
         let keys_to_delete = keys.choose_multiple(rng, 16).cloned().collect::<Vec<_>>();
 
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         b.iter(|| {
@@ -62,7 +64,7 @@ fn trie(c: &mut Criterion) {
             (0..2usize.pow(16)).map(|_| Nibbles::unpack(rng.gen::<[u8; 32]>())).collect::<Vec<_>>();
         let mut trie = TrieNode::Empty;
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         let rng = &mut rand::thread_rng();
@@ -81,7 +83,7 @@ fn trie(c: &mut Criterion) {
             (0..2usize.pow(12)).map(|_| Nibbles::unpack(rng.gen::<[u8; 32]>())).collect::<Vec<_>>();
         let mut trie = TrieNode::Empty;
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         let rng = &mut rand::thread_rng();
@@ -99,7 +101,7 @@ fn trie(c: &mut Criterion) {
             (0..2usize.pow(16)).map(|_| Nibbles::unpack(rng.gen::<[u8; 32]>())).collect::<Vec<_>>();
         let mut trie = TrieNode::Empty;
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         let rng = &mut rand::thread_rng();
@@ -117,7 +119,7 @@ fn trie(c: &mut Criterion) {
             (0..2usize.pow(12)).map(|_| Nibbles::unpack(rng.gen::<[u8; 32]>())).collect::<Vec<_>>();
         let mut trie = TrieNode::Empty;
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         b.iter(|| {
@@ -131,7 +133,7 @@ fn trie(c: &mut Criterion) {
             (0..2usize.pow(16)).map(|_| Nibbles::unpack(rng.gen::<[u8; 32]>())).collect::<Vec<_>>();
         let mut trie = TrieNode::Empty;
         for key in &keys {
-            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher).unwrap();
+            trie.insert(key, key.to_vec().into(), &NoopTrieDBFetcher, &NoopTrieDBHinter).unwrap();
         }
 
         b.iter(|| {

--- a/crates/mpt/src/db/mod.rs
+++ b/crates/mpt/src/db/mod.rs
@@ -267,7 +267,12 @@ where
             trie_account.encode(&mut account_buf);
 
             // Insert or update the account in the trie.
-            self.root_node.insert(&account_path, account_buf.into(), &self.fetcher)?;
+            self.root_node.insert(
+                &account_path,
+                account_buf.into(),
+                &self.fetcher,
+                &self.hinter,
+            )?;
         }
 
         Ok(())
@@ -305,7 +310,7 @@ where
             storage_root.delete(&hashed_slot_key, fetcher, hinter)?;
         } else {
             // Otherwise, update the storage slot.
-            storage_root.insert(&hashed_slot_key, rlp_buf.into(), fetcher)?;
+            storage_root.insert(&hashed_slot_key, rlp_buf.into(), fetcher, hinter)?;
         }
 
         Ok(())


### PR DESCRIPTION
**Description**

When executing multiple blocks with the Kona derive pipeline, we ran into an issue where a `TrieNode` was requested by the fetcher before it was hinted in the state root computation within `update_accounts`. 