### PR TITLE
fix(executor): Don't hold onto intermediate execution cache across block boundaries

### DIFF
--- a/bin/client/src/l2/precompiles/mod.rs
+++ b/bin/client/src/l2/precompiles/mod.rs
@@ -36,7 +36,7 @@ where
     F: TrieDBFetcher,
     H: TrieDBHinter,
 {
-    fn set_precompiles(handler: &mut EvmHandler<'_, (), &mut State<TrieDB<F, H>>>) {
+    fn set_precompiles(handler: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>) {
         let spec_id = handler.cfg.spec_id;
 
         handler.pre_execution.load_precompiles = Arc::new(move || {

--- a/crates/executor/src/builder.rs
+++ b/crates/executor/src/builder.rs
@@ -5,7 +5,6 @@ use alloy_consensus::{Header, Sealable, Sealed};
 use anyhow::Result;
 use kona_derive::types::RollupConfig;
 use kona_mpt::{TrieDB, TrieDBFetcher, TrieDBHinter};
-use revm::StateBuilder;
 
 /// The builder pattern for the [StatelessL2BlockExecutor].
 #[derive(Debug)]
@@ -78,11 +77,10 @@ where
         });
 
         let trie_db = TrieDB::new(parent_header.state_root, parent_header, fetcher, hinter);
-        let state = StateBuilder::new_with_database(trie_db).with_bundle_update().build();
 
         Ok(StatelessL2BlockExecutor {
             config: self.config,
-            state,
+            trie_db,
             _phantom: core::marker::PhantomData::<PO>,
         })
     }

--- a/crates/executor/src/canyon.rs
+++ b/crates/executor/src/canyon.rs
@@ -23,7 +23,7 @@ const CREATE_2_DEPLOYER_BYTECODE: [u8; 1584] = hex!("608060405260043610610043576
 /// deployer contract. This is done by directly setting the code of the create2 deployer account
 /// prior to executing any transactions on the timestamp activation of the fork.
 pub(crate) fn ensure_create2_deployer_canyon<F, H>(
-    db: &mut State<TrieDB<F, H>>,
+    db: &mut State<&mut TrieDB<F, H>>,
     config: &RollupConfig,
     timestamp: u64,
 ) -> Result<()>

--- a/crates/executor/src/precompile.rs
+++ b/crates/executor/src/precompile.rs
@@ -10,7 +10,7 @@ where
     H: TrieDBHinter,
 {
     /// Set the precompiles to use during execution.
-    fn set_precompiles(handler: &mut EvmHandler<'_, (), &mut State<TrieDB<F, H>>>);
+    fn set_precompiles(handler: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>);
 }
 
 /// Default implementation of [PrecompileOverride], which does not override any precompiles.
@@ -22,7 +22,7 @@ where
     F: TrieDBFetcher,
     H: TrieDBHinter,
 {
-    fn set_precompiles(_: &mut EvmHandler<'_, (), &mut State<TrieDB<F, H>>>) {
+    fn set_precompiles(_: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>) {
         // Do nothing
     }
 }


### PR DESCRIPTION
## Overview

Drops the intermediate in-memory `revm` cache between blocks when executing multiple blocks in a row with the `StatelessL2BlockExecutor`.

This fixes a bug where, when executing multiple blocks, the client program does not reach out to the host for the path to the account in the state trie in the _new_ state root. While we do not need support for contiguous block execution in upstream, this allows downstream consumers like Succinct to perform this action with `kona-executor`.