### PR TITLE
fix(kona-derive): Remove DataIter Option Return

### DIFF
--- a/crates/derive/src/sources/calldata.rs
+++ b/crates/derive/src/sources/calldata.rs
@@ -88,10 +88,10 @@ impl<CP: ChainProvider + Send> CalldataSource<CP> {
 impl<CP: ChainProvider + Send> AsyncIterator for CalldataSource<CP> {
     type Item = Bytes;
 
-    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
+    async fn next(&mut self) -> StageResult<Self::Item> {
         if self.load_calldata().await.is_err() {
-            return Some(Err(StageError::BlockFetch(self.block_ref.hash)));
+            return Err(StageError::BlockFetch(self.block_ref.hash));
         }
-        Some(self.calldata.pop_front().ok_or(StageError::Eof))
+        self.calldata.pop_front().ok_or(StageError::Eof)
     }
 }

--- a/crates/derive/src/sources/ethereum.rs
+++ b/crates/derive/src/sources/ethereum.rs
@@ -147,7 +147,7 @@ mod tests {
         assert!(matches!(data_iter, EthereumDataSourceVariant::Calldata(_)));
 
         // Should successfully retrieve a calldata batch from the block
-        let calldata_batch = data_iter.next().await.unwrap().unwrap();
+        let calldata_batch = data_iter.next().await.unwrap();
         assert_eq!(calldata_batch.len(), 119823);
     }
 }

--- a/crates/derive/src/sources/variant.rs
+++ b/crates/derive/src/sources/variant.rs
@@ -30,7 +30,7 @@ where
 {
     type Item = Bytes;
 
-    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
+    async fn next(&mut self) -> StageResult<Self::Item> {
         match self {
             EthereumDataSourceVariant::Calldata(c) => c.next().await,
             EthereumDataSourceVariant::Blob(b) => b.next().await,

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -94,14 +94,13 @@ where
             self.data = Some(self.provider.open_data(&next).await?);
         }
 
-        let data = self.data.as_mut().expect("Cannot be None").next().await.ok_or(StageError::Eof);
-        match data {
-            Ok(Ok(data)) => Ok(data),
-            Err(StageError::Eof) | Ok(Err(StageError::Eof)) => {
+        match self.data.as_mut().expect("Cannot be None").next().await {
+            Ok(data) => Ok(data),
+            Err(StageError::Eof) => {
                 self.data = None;
                 Err(StageError::Eof)
             }
-            Ok(Err(e)) | Err(e) => Err(e),
+            Err(e) => Err(e),
         }
     }
 }

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -40,5 +40,5 @@ pub trait AsyncIterator {
 
     /// Returns the next item in the iterator, or [crate::types::StageError::Eof] if the iterator is
     /// exhausted.
-    async fn next(&mut self) -> Option<StageResult<Self::Item>>;
+    async fn next(&mut self) -> StageResult<Self::Item>;
 }

--- a/crates/derive/src/traits/test_utils.rs
+++ b/crates/derive/src/traits/test_utils.rs
@@ -30,8 +30,8 @@ pub struct TestIter {
 impl AsyncIterator for TestIter {
     type Item = Bytes;
 
-    async fn next(&mut self) -> Option<StageResult<Self::Item>> {
-        Some(self.results.pop().unwrap_or_else(|| Err(StageError::Eof)))
+    async fn next(&mut self) -> StageResult<Self::Item> {
+        self.results.pop().unwrap_or_else(|| Err(StageError::Eof))
     }
 }
 


### PR DESCRIPTION
**Description**

Previously, the `DataIter` returned an `Option<Result<...>>`.

Whenever the `Option` was `None`, the downstream consumers would just return a `StageError::Eof`. Instead, this PR removes the `Option`, and returns a `StageError::Eof` directly if the Option is of variant `None`.