### PR TITLE
fix(deps): Bump Alloy Dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -3759,6 +3759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +3995,20 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_repr",
+]
+
+[[package]]
+name = "superchain-registry"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fa9ab00dc58bbd4fb05e46ccafee39eaf777840c156e30c82f629e73d8cbe2"
+dependencies = [
+ "hashbrown 0.14.5",
+ "lazy_static",
+ "serde",
+ "serde_repr",
+ "superchain-primitives",
+ "toml",
 ]
 
 [[package]]
@@ -4271,10 +4294,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.6"
+name = "toml"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.18",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4284,7 +4322,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.16",
 ]
 
 [[package]]
@@ -4431,6 +4482,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "serde",
+ "superchain-registry",
  "tokio",
  "tracing",
  "tracing-loki",
@@ -4832,6 +4884,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da374e868f54c7f4ad2ad56829827badca388efd645f8cf5fccc61c2b5343504"
+checksum = "f58047cc851e58c26224521d1ecda466e3d746ebca0274cd5427aa660a88c353"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -279,14 +279,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76ecab54890cdea1e4808fc0891c7e6cfcf71fe1a9fe26810c7280ef768f4ed"
+checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
+ "k256",
  "once_cell",
  "serde",
  "sha2",
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca15afde1b6d15e3fc1c97421262b1bbb37aee45752e3c8b6d6f13f776554ff"
+checksum = "20cb76c8a3913f2466c5488f3a915e3a15d15596bdc935558c1a9be75e9ec508"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6f34930b7e3e2744bcc79056c217f00cb2abb33bc5d4ff88da7623c5bb078b"
+checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -318,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f6895fc31b48fa12306ef9b4f78b7764f8bd6d7d91cdb0a40e233704a0f23f"
+checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -338,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b2fb0276a78ec13791446a417c2517eee5c8e8a8c520ae0681975b8056e5c"
+checksum = "77a2864b3470d3c74bf50a70f4a5f3e87a7359870878a268be829d7caff42f13"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -376,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c538bfa893d07e27cb4f3c1ab5f451592b7c526d511d62b576a2ce59e146e4a"
+checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba31bae67773fd5a60020bea900231f8396202b7feca4d0c70c6b59308ab4a8"
+checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -451,19 +452,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184a7a42c7ba9141cc9e76368356168c282c3bc3d9e5d78f3556bdfe39343447"
+checksum = "7e5d76f1e8b22f48b7b8f985782b68e7eb3938780e50e8b646a53e41a598cdf5"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4123ee21f99ba4bd31bfa36ba89112a18a500f8b452f02b35708b1b951e2b9"
+checksum = "605fa8462732bb8fd0645a9941e12961e079d45ae6a44634c826f8229c187bdf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -479,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9416c52959e66ead795a11f4a86c248410e9e368a0765710e57055b8a1774dd6"
+checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -490,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33753c09fa1ad85e5b092b8dc2372f1e337a42e84b9b4cff9fede75ba4adb32"
+checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -562,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b51a291f949f755e6165c3ed562883175c97423703703355f4faa4b7d0a57c"
+checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
 dependencies = [
  "alloy-json-rpc",
  "base64",
@@ -581,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d65871f9f1cafe1ed25cde2f1303be83e6473e995a2d56c275ae4fcce6119c"
+checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -2702,9 +2704,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f491085509d77ebd05dbf75592093a9bebc8e7fc642b90fb4ac13b747d48b2fc"
+checksum = "4d10e10cbbdb3931fed5109bbd570c0a6cf0ce08db1f93401cfb5cefc51998d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3972,9 +3974,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superchain-primitives"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88a85697c4aa789e1465c86f855cfaecd8d38553961f1fec77af6ea51d30e8e"
+checksum = "b82ed8be21bf40a5103f855c93c7d15091536adfb0aa0a862e6b7c1f93d16c99"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3982,7 +3984,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
- "hashbrown 0.14.5",
  "serde",
  "serde_repr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ async-trait = "0.1.80"
 # Ethereum
 alloy-primitives = { version = "0.7.6", default-features = false }
 alloy-rlp = { version = "0.3.5", default-features = false }
-alloy-consensus = { version = "0.1", default-features = false }
-op-alloy-consensus = { version = "=0.1.2", default-features = false }
-alloy-eips = { version = "0.1", default-features = false }
+alloy-consensus = { version = "0.2", default-features = false }
+op-alloy-consensus = { version = "0.1.4", default-features = false }
+alloy-eips = { version = "0.2", default-features = false }
 revm = { git = "https://github.com/bluealloy/revm", tag = "v37", version = "10.0.0", default-features = false }
 
 [profile.dev]

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -27,10 +27,10 @@ kona-mpt = { path = "../../crates/mpt", version = "0.0.2" }
 kona-derive = { path = "../../crates/derive", version = "0.0.2", features = ["online"] }
 
 # external
-alloy-provider = { version = "0.1" } 
-alloy-transport-http = { version = "0.1" } 
-alloy-rpc-client = { version = "0.1" } 
-alloy-rpc-types = { version = "0.1" } 
+alloy-provider = { version = "0.2" } 
+alloy-transport-http = { version = "0.2" } 
+alloy-rpc-client = { version = "0.2" } 
+alloy-rpc-types = { version = "0.2" } 
 reqwest = "0.12"
 tokio = { version = "1.37.0", features = ["full"] }
 futures = "0.3"

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -41,10 +41,10 @@ serde = { version = "1.0.203", default-features = false, features = ["derive"], 
 # `online` feature dependencies
 c-kzg = { version = "1.0.2", default-features = false, optional = true }
 sha2 = { version = "0.10.8", default-features = false, optional = true }
-alloy-transport = { version = "0.1", default-features = false, optional = true }
-alloy-provider = { version = "0.1", default-features = false, optional = true }
-alloy-transport-http = { version = "0.1", optional = true } 
-alloy-rpc-types = { version = "0.1", default-features = false, optional = true }
+alloy-transport = { version = "0.2", default-features = false, optional = true }
+alloy-provider = { version = "0.2", default-features = false, optional = true }
+alloy-transport-http = { version = "0.2", optional = true } 
+alloy-rpc-types = { version = "0.2", default-features = false, optional = true }
 serde_json = { version = "1.0.94", default-features = false, optional = true }
 reqwest = { version = "0.12.4", default-features = false, optional = true }
 
@@ -53,16 +53,16 @@ lazy_static = { version = "1.5.0", optional = true }
 prometheus = { version = "0.13.4", features = ["process"], optional = true }
 
 # `test-utils` feature dependencies
-alloy-node-bindings = { version = "0.1", default-features = false, optional = true }
+alloy-node-bindings = { version = "0.2", default-features = false, optional = true }
 tracing-subscriber = { version = "0.3.18", optional = true }
-alloy-rpc-client = { version = "0.1", default-features = false, optional = true }
+alloy-rpc-client = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.38", features = ["full"] }
 proptest = "1.4.0"
 tracing-subscriber = "0.3.18"
-alloy-node-bindings = { version = "0.1", default-features = false }
-alloy-rpc-client = { version = "0.1", default-features = false }
+alloy-node-bindings = { version = "0.2", default-features = false }
+alloy-rpc-client = { version = "0.2", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 
 [features]

--- a/crates/derive/src/sources/ethereum.rs
+++ b/crates/derive/src/sources/ethereum.rs
@@ -45,7 +45,7 @@ where
                 .genesis
                 .system_config
                 .as_ref()
-                .map(|sc| sc.batcher_addr)
+                .map(|sc| sc.batcher_address)
                 .unwrap_or_default(),
             batch_inbox_address: cfg.batch_inbox_address,
         }
@@ -133,8 +133,7 @@ mod tests {
         let block_ref = BlockInfo { number: 10, ..Default::default() };
 
         let mut cfg = RollupConfig::default();
-        cfg.genesis.system_config =
-            Some(SystemConfig { batcher_addr: batcher_address, ..Default::default() });
+        cfg.genesis.system_config = Some(SystemConfig { batcher_address, ..Default::default() });
         cfg.batch_inbox_address = batch_inbox;
 
         // load a test batcher transaction

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -34,7 +34,7 @@ pub struct L1Traversal<Provider: ChainProvider> {
 #[async_trait]
 impl<F: ChainProvider + Send> L1RetrievalProvider for L1Traversal<F> {
     fn batcher_addr(&self) -> Address {
-        self.system_config.batcher_addr
+        self.system_config.batcher_address
     }
 
     async fn next_l1_block(&mut self) -> StageResult<Option<BlockInfo>> {
@@ -266,6 +266,6 @@ pub(crate) mod tests {
         assert_eq!(traversal.next_l1_block().await.unwrap_err(), StageError::Eof);
         assert!(traversal.advance_origin().await.is_ok());
         let expected = address!("000000000000000000000000000000000000bEEF");
-        assert_eq!(traversal.system_config.batcher_addr, expected);
+        assert_eq!(traversal.system_config.batcher_address, expected);
     }
 }

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -23,9 +23,9 @@ alloy-trie = { version = "0.4.1", default-features = false }
 [dev-dependencies]
 alloy-consensus.workspace = true
 tokio = { version = "1.38.0", features = ["full"] }
-alloy-provider = { version = "0.1" }
-alloy-rpc-types = { version = "0.1" }
-alloy-transport-http = { version = "0.1" }
+alloy-provider = { version = "0.2" }
+alloy-rpc-types = { version = "0.2" }
+alloy-transport-http = { version = "0.2" }
 reqwest = "0.12.4"
 tracing-subscriber = "0.3.18"
 futures = { version = "0.3.30", default-features = false }

--- a/crates/plasma/Cargo.toml
+++ b/crates/plasma/Cargo.toml
@@ -24,8 +24,8 @@ kona-derive = { path = "../derive", version = "0.0.2" }
 serde = { version = "1.0.203", default-features = false, features = ["derive"], optional = true }
 
 # `online` feature dependencies
-alloy-transport-http = { version = "0.1", optional = true } 
-alloy-provider = { version = "0.1", default-features = false, optional = true }
+alloy-transport-http = { version = "0.2", optional = true } 
+alloy-provider = { version = "0.2", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ alloy-eips.workspace = true
 op-alloy-consensus.workspace = true
 
 # Superchain Registry
-superchain-primitives = { version = "=0.1.1", default-features = false }
+superchain-primitives = { version = "0.2", default-features = false }
 
 # Alloy Types
 alloy-sol-types = { version = "0.7.6", default-features = false }

--- a/crates/primitives/src/block_info.rs
+++ b/crates/primitives/src/block_info.rs
@@ -148,7 +148,7 @@ impl L1BlockInfoTx {
                 base_fee: l1_header.base_fee_per_gas.unwrap_or(0) as u64,
                 block_hash: l1_header.hash_slow(),
                 sequence_number,
-                batcher_address: system_config.batcher_addr,
+                batcher_address: system_config.batcher_address,
                 blob_base_fee: l1_header.blob_fee().unwrap_or(1),
                 blob_base_fee_scalar,
                 base_fee_scalar,
@@ -160,7 +160,7 @@ impl L1BlockInfoTx {
                 base_fee: l1_header.base_fee_per_gas.unwrap_or(0) as u64,
                 block_hash: l1_header.hash_slow(),
                 sequence_number,
-                batcher_address: system_config.batcher_addr,
+                batcher_address: system_config.batcher_address,
                 l1_fee_overhead: system_config.overhead,
                 l1_fee_scalar: system_config.scalar,
             }))
@@ -472,7 +472,7 @@ mod test {
         assert_eq!(l1_info.base_fee, l1_header.base_fee_per_gas.unwrap_or(0) as u64);
         assert_eq!(l1_info.block_hash, l1_header.hash_slow());
         assert_eq!(l1_info.sequence_number, sequence_number);
-        assert_eq!(l1_info.batcher_address, system_config.batcher_addr);
+        assert_eq!(l1_info.batcher_address, system_config.batcher_address);
         assert_eq!(l1_info.l1_fee_overhead, system_config.overhead);
         assert_eq!(l1_info.l1_fee_scalar, system_config.scalar);
     }
@@ -503,7 +503,7 @@ mod test {
         assert_eq!(l1_info.base_fee, l1_header.base_fee_per_gas.unwrap_or(0) as u64);
         assert_eq!(l1_info.block_hash, l1_header.hash_slow());
         assert_eq!(l1_info.sequence_number, sequence_number);
-        assert_eq!(l1_info.batcher_address, system_config.batcher_addr);
+        assert_eq!(l1_info.batcher_address, system_config.batcher_address);
         assert_eq!(l1_info.blob_base_fee, l1_header.blob_fee().unwrap_or(1));
 
         let scalar = system_config.scalar.to_be_bytes::<32>();

--- a/crates/primitives/src/payload.rs
+++ b/crates/primitives/src/payload.rs
@@ -218,7 +218,7 @@ impl L2ExecutionPayloadEnvelope {
         };
 
         Ok(SystemConfig {
-            batcher_addr: l1_info.batcher_address(),
+            batcher_address: l1_info.batcher_address(),
             overhead: l1_info.l1_fee_overhead(),
             scalar: l1_fee_scalar,
             gas_limit: execution_payload.gas_limit as u64,

--- a/examples/trusted-sync/Cargo.toml
+++ b/examples/trusted-sync/Cargo.toml
@@ -26,6 +26,6 @@ tokio = { version = "1.37.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 serde = { version = "1.0.198", features = ["derive"] }
-alloy-provider = { version = "0.1", default-features = false }
-alloy-rpc-types = { version = "0.1" }
-alloy-transport = { version = "0.1", default-features = false }
+alloy-provider = { version = "0.2", default-features = false }
+alloy-rpc-types = { version = "0.2" }
+alloy-transport = { version = "0.2", default-features = false }

--- a/examples/trusted-sync/Cargo.toml
+++ b/examples/trusted-sync/Cargo.toml
@@ -29,3 +29,4 @@ serde = { version = "1.0.198", features = ["derive"] }
 alloy-provider = { version = "0.2", default-features = false }
 alloy-rpc-types = { version = "0.2" }
 alloy-transport = { version = "0.2", default-features = false }
+superchain-registry = "0.2"

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use kona_derive::{online::*, types::StageError};
 use std::sync::Arc;
+use superchain_registry::ROLLUP_CONFIGS;
 use tracing::{debug, error, info, trace, warn};
 
 mod cli;
@@ -46,8 +47,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     let l2_chain_id =
         l2_provider.chain_id().await.expect("Failed to fetch chain ID from L2 provider");
     metrics::CHAIN_ID.inc_by(l2_chain_id);
-    let cfg = RollupConfig::from_l2_chain_id(l2_chain_id)
-        .expect("Failed to fetch rollup config from L2 chain ID");
+    let cfg = ROLLUP_CONFIGS.get(&l2_chain_id).expect("Failed to get rollup config from the superchain registry for the provider's l2 chain id").clone();
     let cfg = Arc::new(cfg);
     metrics::GENESIS_L2_BLOCK.inc_by(cfg.genesis.l2.number);
 


### PR DESCRIPTION
**Description**

Bumps all alloy dependencies to `0.2.*` as well as the `superchain-registry` + `superchain-primitives` versions. This allows `kona-derive` to be compatible with anvil and foundry deps for `op-test-vectors`.

**Metadata**

Fixes #392
Fixes #261