### PR TITLE
feat(derive+trusted-sync): online blob provider with fallback

### DIFF
--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -243,9 +243,16 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
             return Ok(Vec::new());
         }
 
+        // Extract the genesis timestamp and slot interval from the primary provider.
+        let slot = S::slot(
+            self.primary.genesis_time.expect("Genesis Config Loaded"),
+            self.primary.slot_interval.expect("Config Spec Loaded"),
+            block_ref.timestamp,
+        )
+        .map_err(BlobProviderError::Slot)?;
+
         // Fetch blob sidecars for the given block reference and blob hashes.
-        let sidecars =
-            self.fallback.beacon_blob_side_cars(block_ref.timestamp, blob_hashes).await?;
+        let sidecars = self.fallback.beacon_blob_side_cars(slot, blob_hashes).await?;
 
         // Filter blob sidecars that match the indicies in the specified list.
         let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<_>>();

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -353,8 +353,8 @@ where
 /// The fallback provider is optional and can be set using the [Self::with_fallback] method.
 ///
 /// Two convenience methods are available for initializing the providers from beacon client URLs:
-/// - [Self::with_primary_beacon_client_url] for the primary beacon client.
-/// - [Self::with_fallback_beacon_client_url] for the fallback beacon client.
+/// - [Self::with_primary] for the primary beacon client.
+/// - [Self::with_fallback] for the fallback beacon client.
 #[derive(Debug, Clone)]
 pub struct OnlineBlobProviderBuilder<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation> {
     beacon_client: Option<B>,

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -589,7 +589,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_blobs_fallback() {
+    async fn test_get_blob_fallback() {
+        let json_bytes = include_bytes!("testdata/eth_v1_beacon_sidecars_goerli.json");
+        let sidecars: APIGetBlobSidecarsResponse = serde_json::from_slice(json_bytes).unwrap();
+
+        // Provide no sidecars to the primary provider to trigger a fallback fetch
+        let beacon_client = MockBeaconClient {
+            beacon_genesis: Some(APIGenesisResponse::new(10)),
+            config_spec: Some(APIConfigResponse::new(12)),
+            blob_sidecars: None,
+            ..Default::default()
+        };
+        let fallback_client =
+            MockBeaconClient { blob_sidecars: Some(sidecars), ..Default::default() };
+        let mut blob_provider: OnlineBlobProviderWithFallback<_, _, SimpleSlotDerivation> =
+            OnlineBlobProviderWithFallback::new(
+                OnlineBlobProvider::new(beacon_client, None, None),
+                fallback_client,
+            );
+        let block_ref = BlockInfo { timestamp: 15, ..Default::default() };
+        let blob_hashes = vec![
+            IndexedBlobHash {
+                index: 0,
+                hash: b256!("011075cbb20f3235b3179a5dff22689c410cd091692180f4b6a12be77ea0f586"),
+            },
+            IndexedBlobHash {
+                index: 1,
+                hash: b256!("010a9e10aab79bab62e10a5b83c164a91451b6ef56d31ac95a9514ffe6d6b4e6"),
+            },
+            IndexedBlobHash {
+                index: 2,
+                hash: b256!("016122c8e41c69917b688240707d107aa6d2a480343e4e323e564241769a6b4a"),
+            },
+            IndexedBlobHash {
+                index: 3,
+                hash: b256!("01df1f9ae707f5847513c9c430b683182079edf2b1f94ee12e4daae7f3c8c309"),
+            },
+            IndexedBlobHash {
+                index: 4,
+                hash: b256!("01e5ee2f6cbbafb3c03f05f340e795fe5b5a8edbcc9ac3fc7bd3d1940b99ef3c"),
+            },
+        ];
+        let blobs = blob_provider.get_blobs(&block_ref, &blob_hashes).await.unwrap();
+        assert_eq!(blobs.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_get_blobs_fallback_partial_sidecar() {
         let json_bytes = include_bytes!("testdata/eth_v1_beacon_sidecars_goerli.json");
         let all_sidecars: APIGetBlobSidecarsResponse = serde_json::from_slice(json_bytes).unwrap();
 

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -405,7 +405,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
     }
 
     /// Adds a fallback blob provider to the builder. This is optional.
-    pub fn with_fallback(mut self, fallback: F) -> Self {
+    pub fn with_fallback_provider(mut self, fallback: F) -> Self {
         self.fallback = Some(fallback);
         self
     }
@@ -420,7 +420,7 @@ impl<F: BlobSidecarProvider, S: SlotDerivation + Sync>
     OnlineBlobProviderBuilder<OnlineBeaconClient, F, S>
 {
     /// Adds a primary [OnlineBeaconClient] to the builder using the specified HTTP URL.
-    pub fn with_primary_beacon_client_url(mut self, url: String) -> Self {
+    pub fn with_primary(mut self, url: String) -> Self {
         self.beacon_client = Some(OnlineBeaconClient::new_http(url));
         self
     }
@@ -430,8 +430,8 @@ impl<B: BeaconClient + Send + Sync, S: SlotDerivation + Sync>
     OnlineBlobProviderBuilder<B, OnlineBeaconClient, S>
 {
     /// Adds a fallback [OnlineBeaconClient] to the builder using the specified HTTP URL.
-    pub fn with_fallback_beacon_client_url(mut self, url: String) -> Self {
-        self.fallback = Some(OnlineBeaconClient::new_http(url));
+    pub fn with_fallback(mut self, maybe_url: Option<String>) -> Self {
+        self.fallback = maybe_url.map(OnlineBeaconClient::new_http);
         self
     }
 }

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -1,7 +1,7 @@
 //! Contains an online implementation of the [BlobProvider] trait.
 
 use crate::{
-    online::BeaconClient,
+    online::{BeaconClient, OnlineBeaconClient},
     traits::BlobProvider,
     types::{APIBlobSidecar, Blob, BlobProviderError, BlobSidecar, BlockInfo, IndexedBlobHash},
 };
@@ -9,6 +9,7 @@ use alloc::{boxed::Box, vec::Vec};
 use anyhow::{anyhow, ensure};
 use async_trait::async_trait;
 use core::marker::PhantomData;
+use tracing::warn;
 
 /// Specifies the derivation of a slot from a timestamp.
 pub trait SlotDerivation {
@@ -220,7 +221,7 @@ pub struct OnlineBlobProviderWithFallback<
     S: SlotDerivation,
 > {
     primary: OnlineBlobProvider<B, S>,
-    fallback: F,
+    fallback: Option<F>,
     _slot_derivation: PhantomData<S>,
 }
 
@@ -229,16 +230,23 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
 {
     /// Creates a new instance of the [OnlineBlobProviderWithFallback] with the
     /// specified primary and fallback providers.
-    pub fn new(primary: OnlineBlobProvider<B, S>, fallback: F) -> Self {
+    pub fn new(primary: OnlineBlobProvider<B, S>, fallback: Option<F>) -> Self {
         Self { primary, fallback, _slot_derivation: PhantomData }
     }
 
-    /// Attempts to fetch blob sidecars from the fallback provider.
+    /// Attempts to fetch blob sidecars from the fallback provider, if configured.
+    /// Calling this method without a fallback provider will return an error.
     async fn fallback_fetch_filtered_sidecars(
         &self,
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],
     ) -> Result<Vec<BlobSidecar>, BlobProviderError> {
+        let Some(fallback) = self.fallback.as_ref() else {
+            return Err(BlobProviderError::Custom(anyhow::anyhow!(
+                "cannot fetch blobs: the primary blob provider failed, and no fallback is configured"
+            )));
+        };
+
         if blob_hashes.is_empty() {
             return Ok(Vec::new());
         }
@@ -252,7 +260,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
         .map_err(BlobProviderError::Slot)?;
 
         // Fetch blob sidecars for the given block reference and blob hashes.
-        let sidecars = self.fallback.beacon_blob_side_cars(slot, blob_hashes).await?;
+        let sidecars = fallback.beacon_blob_side_cars(slot, blob_hashes).await?;
 
         // Filter blob sidecars that match the indicies in the specified list.
         let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<_>>();
@@ -285,19 +293,18 @@ where
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],
     ) -> Result<Vec<Blob>, BlobProviderError> {
-        crate::inc!(PROVIDER_CALLS, &["blob_provider", "get_blobs"]);
-        crate::timer!(START, PROVIDER_RESPONSE_TIME, &["blob_provider", "get_blobs"], timer);
         match self.primary.get_blobs(block_ref, blob_hashes).await {
             Ok(blobs) => Ok(blobs),
-            Err(_primary_err) => {
+            Err(primary_err) => {
                 crate::inc!(PROVIDER_ERRORS, &["blob_provider", "get_blobs", "primary"]);
+                warn!(target: "blob_provider", "Primary provider failed: {:?}", primary_err);
 
                 // Fetch the blob sidecars for the given block reference and blob hashes.
                 let sidecars =
                     match self.fallback_fetch_filtered_sidecars(block_ref, blob_hashes).await {
                         Ok(sidecars) => sidecars,
                         Err(e) => {
-                            crate::timer!(DISCARD, timer);
+                            warn!(target: "blob_provider", "Fallback provider failed: {:?}", e);
                             crate::inc!(
                                 PROVIDER_ERRORS,
                                 &["blob_provider", "get_blobs", "fallback_fetch_filtered_sidecars"]
@@ -323,7 +330,6 @@ where
                 {
                     Ok(blobs) => blobs,
                     Err(e) => {
-                        crate::timer!(DISCARD, timer);
                         crate::inc!(
                             PROVIDER_ERRORS,
                             &["blob_provider", "get_blobs", "fallback_verify_blob"]
@@ -335,6 +341,113 @@ where
                 Ok(blobs)
             }
         }
+    }
+}
+
+/// A builder for a [OnlineBlobProviderWithFallback] instance.
+///
+/// This builder allows for the construction of a blob provider that
+/// uses a primary beacon node and can fallback to a secondary [BlobSidecarProvider]
+/// if the primary fails to fetch blob sidecars.
+///
+/// The fallback provider is optional and can be set using the [Self::with_fallback] method.
+///
+/// Two convenience methods are available for initializing the providers from beacon client URLs:
+/// - [Self::with_primary_beacon_client_url] for the primary beacon client.
+/// - [Self::with_fallback_beacon_client_url] for the fallback beacon client.
+#[derive(Debug, Clone)]
+pub struct OnlineBlobProviderBuilder<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation> {
+    beacon_client: Option<B>,
+    fallback: Option<F>,
+    genesis_time: Option<u64>,
+    slot_interval: Option<u64>,
+    _slot_derivation: PhantomData<S>,
+}
+
+impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation> Default
+    for OnlineBlobProviderBuilder<B, F, S>
+{
+    fn default() -> Self {
+        Self {
+            beacon_client: None,
+            fallback: None,
+            genesis_time: None,
+            slot_interval: None,
+            _slot_derivation: PhantomData,
+        }
+    }
+}
+
+impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
+    OnlineBlobProviderBuilder<B, F, S>
+{
+    /// Creates a new [OnlineBlobProviderBuilder].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a primary beacon client to the builder. This is required.
+    pub fn with_beacon_client(mut self, beacon_client: B) -> Self {
+        self.beacon_client = Some(beacon_client);
+        self
+    }
+
+    /// Adds a genesis time to the builder. This is optional.
+    pub fn with_genesis_time(mut self, genesis_time: u64) -> Self {
+        self.genesis_time = Some(genesis_time);
+        self
+    }
+
+    /// Adds a slot interval to the builder. This is optional.
+    pub fn with_slot_interval(mut self, slot_interval: u64) -> Self {
+        self.slot_interval = Some(slot_interval);
+        self
+    }
+
+    /// Adds a fallback blob provider to the builder. This is optional.
+    pub fn with_fallback(mut self, fallback: F) -> Self {
+        self.fallback = Some(fallback);
+        self
+    }
+
+    /// Builds the [OnlineBlobProviderWithFallback] instance.
+    pub fn build(self) -> OnlineBlobProviderWithFallback<B, F, S> {
+        self.into()
+    }
+}
+
+impl<F: BlobSidecarProvider, S: SlotDerivation + Sync>
+    OnlineBlobProviderBuilder<OnlineBeaconClient, F, S>
+{
+    /// Adds a primary [OnlineBeaconClient] to the builder using the specified HTTP URL.
+    pub fn with_primary_beacon_client_url(mut self, url: String) -> Self {
+        self.beacon_client = Some(OnlineBeaconClient::new_http(url));
+        self
+    }
+}
+
+impl<B: BeaconClient + Send + Sync, S: SlotDerivation + Sync>
+    OnlineBlobProviderBuilder<B, OnlineBeaconClient, S>
+{
+    /// Adds a fallback [OnlineBeaconClient] to the builder using the specified HTTP URL.
+    pub fn with_fallback_beacon_client_url(mut self, url: String) -> Self {
+        self.fallback = Some(OnlineBeaconClient::new_http(url));
+        self
+    }
+}
+
+impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
+    From<OnlineBlobProviderBuilder<B, F, S>> for OnlineBlobProviderWithFallback<B, F, S>
+{
+    fn from(builder: OnlineBlobProviderBuilder<B, F, S>) -> Self {
+        Self::new(
+            OnlineBlobProvider::new(
+                builder.beacon_client.expect("Primary beacon client must be set"),
+                builder.genesis_time,
+                builder.slot_interval,
+            ),
+            builder.fallback,
+        )
     }
 }
 
@@ -612,7 +725,7 @@ mod tests {
         let mut blob_provider: OnlineBlobProviderWithFallback<_, _, SimpleSlotDerivation> =
             OnlineBlobProviderWithFallback::new(
                 OnlineBlobProvider::new(beacon_client, None, None),
-                fallback_client,
+                Some(fallback_client),
             );
         let block_ref = BlockInfo { timestamp: 15, ..Default::default() };
         let blob_hashes = vec![
@@ -662,7 +775,7 @@ mod tests {
         let mut blob_provider: OnlineBlobProviderWithFallback<_, _, SimpleSlotDerivation> =
             OnlineBlobProviderWithFallback::new(
                 OnlineBlobProvider::new(beacon_client, None, None),
-                fallback_client,
+                Some(fallback_client),
             );
         let block_ref = BlockInfo { timestamp: 15, ..Default::default() };
         let blob_hashes = vec![

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -176,6 +176,161 @@ where
     }
 }
 
+/// The minimal interface required to fetch sidecars from a remote blob store.
+#[async_trait]
+pub trait BlobSidecarProvider {
+    /// Fetches blob sidecars that were confirmed in the specified L1 block with the given indexed
+    /// hashes. Order of the returned sidecars is guaranteed to be that of the hashes. Blob data is
+    /// not checked for validity.
+    ///
+    /// Consensus specs: <https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars>
+    async fn beacon_blob_side_cars(
+        &self,
+        slot: u64,
+        hashes: &[IndexedBlobHash],
+    ) -> anyhow::Result<Vec<APIBlobSidecar>>;
+}
+
+/// Blanket implementation of the [BlobSidecarProvider] trait for all types that
+/// implemend [BeaconClient], which has a superset of the required functionality.
+#[async_trait]
+impl<B: BeaconClient + Send + Sync> BlobSidecarProvider for B {
+    async fn beacon_blob_side_cars(
+        &self,
+        slot: u64,
+        hashes: &[IndexedBlobHash],
+    ) -> anyhow::Result<Vec<APIBlobSidecar>> {
+        self.beacon_blob_side_cars(slot, hashes).await
+    }
+}
+
+/// An online blob provider that optionally falls back to a secondary provider if the
+/// primary fails to fetch blob sidecars.
+///
+/// This is useful for scenarios where blobs have been evicted from the primary provider's
+/// blob store and need to be fetched from a remote archive API. The default eviction
+/// policy on Ethereum is to keep blobs for 18 days.
+///
+/// Blob storage APIs are expected to implement the [BlobSidecarProvider] trait.
+/// One example can be found at <https://github.com/base-org/blob-archiver>
+#[derive(Debug, Clone)]
+pub struct OnlineBlobProviderWithFallback<
+    B: BeaconClient,
+    F: BlobSidecarProvider,
+    S: SlotDerivation,
+> {
+    primary: OnlineBlobProvider<B, S>,
+    fallback: F,
+    _slot_derivation: PhantomData<S>,
+}
+
+impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
+    OnlineBlobProviderWithFallback<B, F, S>
+{
+    /// Creates a new instance of the [OnlineBlobProviderWithFallback] with the
+    /// specified primary and fallback providers.
+    pub fn new(primary: OnlineBlobProvider<B, S>, fallback: F) -> Self {
+        Self { primary, fallback, _slot_derivation: PhantomData }
+    }
+
+    /// Attempts to fetch blob sidecars from the fallback provider.
+    async fn fallback_fetch_filtered_sidecars(
+        &self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[IndexedBlobHash],
+    ) -> Result<Vec<BlobSidecar>, BlobProviderError> {
+        if blob_hashes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fetch blob sidecars for the given block reference and blob hashes.
+        let sidecars =
+            self.fallback.beacon_blob_side_cars(block_ref.timestamp, blob_hashes).await?;
+
+        // Filter blob sidecars that match the indicies in the specified list.
+        let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<_>>();
+        let filtered = sidecars
+            .into_iter()
+            .filter(|s| blob_hash_indicies.contains(&(s.inner.index as usize)))
+            .collect::<Vec<_>>();
+
+        // Validate the correct number of blob sidecars were retrieved.
+        if blob_hashes.len() != filtered.len() {
+            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
+        }
+
+        Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
+    }
+}
+
+#[async_trait]
+impl<B, F, S> BlobProvider for OnlineBlobProviderWithFallback<B, F, S>
+where
+    B: BeaconClient + Send + Sync,
+    F: BlobSidecarProvider + Send + Sync,
+    S: SlotDerivation + Send + Sync,
+{
+    /// Fetches blob sidecars that were confirmed in the specified L1 block with the given indexed
+    /// hashes. The blobs are validated for their index and hashes using the specified
+    /// [IndexedBlobHash].
+    async fn get_blobs(
+        &mut self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[IndexedBlobHash],
+    ) -> Result<Vec<Blob>, BlobProviderError> {
+        crate::inc!(PROVIDER_CALLS, &["blob_provider", "get_blobs"]);
+        crate::timer!(START, PROVIDER_RESPONSE_TIME, &["blob_provider", "get_blobs"], timer);
+        match self.primary.get_blobs(block_ref, blob_hashes).await {
+            Ok(blobs) => Ok(blobs),
+            Err(_primary_err) => {
+                crate::inc!(PROVIDER_ERRORS, &["blob_provider", "get_blobs", "primary"]);
+
+                // Fetch the blob sidecars for the given block reference and blob hashes.
+                let sidecars =
+                    match self.fallback_fetch_filtered_sidecars(block_ref, blob_hashes).await {
+                        Ok(sidecars) => sidecars,
+                        Err(e) => {
+                            crate::timer!(DISCARD, timer);
+                            crate::inc!(
+                                PROVIDER_ERRORS,
+                                &["blob_provider", "get_blobs", "fallback_fetch_filtered_sidecars"]
+                            );
+                            return Err(e);
+                        }
+                    };
+
+                // Validate the blob sidecars straight away with the `IndexedBlobHash`es.
+                let blobs = match sidecars
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, sidecar)| {
+                        let hash = blob_hashes
+                            .get(i)
+                            .ok_or(anyhow!("fallback: failed to get blob hash"))?;
+                        match sidecar.verify_blob(hash) {
+                            Ok(_) => Ok(sidecar.blob),
+                            Err(e) => Err(e),
+                        }
+                    })
+                    .collect::<anyhow::Result<Vec<Blob>>>()
+                {
+                    Ok(blobs) => blobs,
+                    Err(e) => {
+                        crate::timer!(DISCARD, timer);
+                        crate::inc!(
+                            PROVIDER_ERRORS,
+                            &["blob_provider", "get_blobs", "fallback_verify_blob"]
+                        );
+                        return Err(BlobProviderError::Custom(e));
+                    }
+                };
+
+                Ok(blobs)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -431,5 +586,55 @@ mod tests {
             result.unwrap_err(),
             BlobProviderError::Custom(anyhow::anyhow!("blob at index 0 failed verification"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_blobs_fallback() {
+        let json_bytes = include_bytes!("testdata/eth_v1_beacon_sidecars_goerli.json");
+        let all_sidecars: APIGetBlobSidecarsResponse = serde_json::from_slice(json_bytes).unwrap();
+
+        let online_sidecars = APIGetBlobSidecarsResponse {
+            // Remove some sidecars from the online provider to trigger a fallback fetch
+            data: all_sidecars.data.clone().into_iter().take(2).collect::<Vec<_>>(),
+        };
+
+        let beacon_client = MockBeaconClient {
+            beacon_genesis: Some(APIGenesisResponse::new(10)),
+            config_spec: Some(APIConfigResponse::new(12)),
+            blob_sidecars: Some(online_sidecars),
+            ..Default::default()
+        };
+        let fallback_client =
+            MockBeaconClient { blob_sidecars: Some(all_sidecars), ..Default::default() };
+        let mut blob_provider: OnlineBlobProviderWithFallback<_, _, SimpleSlotDerivation> =
+            OnlineBlobProviderWithFallback::new(
+                OnlineBlobProvider::new(beacon_client, None, None),
+                fallback_client,
+            );
+        let block_ref = BlockInfo { timestamp: 15, ..Default::default() };
+        let blob_hashes = vec![
+            IndexedBlobHash {
+                index: 0,
+                hash: b256!("011075cbb20f3235b3179a5dff22689c410cd091692180f4b6a12be77ea0f586"),
+            },
+            IndexedBlobHash {
+                index: 1,
+                hash: b256!("010a9e10aab79bab62e10a5b83c164a91451b6ef56d31ac95a9514ffe6d6b4e6"),
+            },
+            IndexedBlobHash {
+                index: 2,
+                hash: b256!("016122c8e41c69917b688240707d107aa6d2a480343e4e323e564241769a6b4a"),
+            },
+            IndexedBlobHash {
+                index: 3,
+                hash: b256!("01df1f9ae707f5847513c9c430b683182079edf2b1f94ee12e4daae7f3c8c309"),
+            },
+            IndexedBlobHash {
+                index: 4,
+                hash: b256!("01e5ee2f6cbbafb3c03f05f340e795fe5b5a8edbcc9ac3fc7bd3d1940b99ef3c"),
+            },
+        ];
+        let blobs = blob_provider.get_blobs(&block_ref, &blob_hashes).await.unwrap();
+        assert_eq!(blobs.len(), 5);
     }
 }

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -5,7 +5,7 @@ use crate::{
     traits::BlobProvider,
     types::{APIBlobSidecar, Blob, BlobProviderError, BlobSidecar, BlockInfo, IndexedBlobHash},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use anyhow::{anyhow, ensure};
 use async_trait::async_trait;
 use core::marker::PhantomData;

--- a/crates/derive/src/online/mod.rs
+++ b/crates/derive/src/online/mod.rs
@@ -22,7 +22,9 @@ mod alloy_providers;
 pub use alloy_providers::{AlloyChainProvider, AlloyL2ChainProvider};
 
 mod blob_provider;
-pub use blob_provider::{OnlineBlobProvider, OnlineBlobProviderWithFallback, SimpleSlotDerivation};
+pub use blob_provider::{
+    BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderWithFallback, SimpleSlotDerivation,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/derive/src/online/mod.rs
+++ b/crates/derive/src/online/mod.rs
@@ -23,7 +23,8 @@ pub use alloy_providers::{AlloyChainProvider, AlloyL2ChainProvider};
 
 mod blob_provider;
 pub use blob_provider::{
-    BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderWithFallback, SimpleSlotDerivation,
+    BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderBuilder,
+    OnlineBlobProviderWithFallback, SimpleSlotDerivation,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/derive/src/online/mod.rs
+++ b/crates/derive/src/online/mod.rs
@@ -22,7 +22,7 @@ mod alloy_providers;
 pub use alloy_providers::{AlloyChainProvider, AlloyL2ChainProvider};
 
 mod blob_provider;
-pub use blob_provider::{OnlineBlobProvider, SimpleSlotDerivation};
+pub use blob_provider::{OnlineBlobProvider, OnlineBlobProviderWithFallback, SimpleSlotDerivation};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/derive/src/online/pipeline.rs
+++ b/crates/derive/src/online/pipeline.rs
@@ -2,8 +2,8 @@
 
 use super::{
     AlloyChainProvider, AlloyL2ChainProvider, BlockInfo, DerivationPipeline, EthereumDataSource,
-    OnlineBeaconClient, OnlineBlobProvider, PipelineBuilder, RollupConfig, SimpleSlotDerivation,
-    StatefulAttributesBuilder,
+    OnlineBeaconClient, OnlineBlobProviderWithFallback, PipelineBuilder, RollupConfig,
+    SimpleSlotDerivation, StatefulAttributesBuilder,
 };
 use alloc::sync::Arc;
 // Pipeline internal stages aren't re-exported at the module-level.
@@ -18,7 +18,7 @@ pub type OnlinePipeline =
 /// An `online` Ethereum data source.
 pub type OnlineDataProvider = EthereumDataSource<
     AlloyChainProvider,
-    OnlineBlobProvider<OnlineBeaconClient, SimpleSlotDerivation>,
+    OnlineBlobProviderWithFallback<OnlineBeaconClient, OnlineBeaconClient, SimpleSlotDerivation>,
 >;
 
 /// An `online` payload attributes builder for the `AttributesQueue` stage of the derivation

--- a/examples/trusted-sync/src/cli.rs
+++ b/examples/trusted-sync/src/cli.rs
@@ -110,11 +110,9 @@ impl Cli {
         })
     }
 
-    pub fn blob_archiver_url(&self) -> Result<String> {
-        Ok(if let Some(s) = self.blob_archiver_url.clone() {
-            s
-        } else {
-            std::env::var(BLOB_ARCHIVER_URL).map_err(|e| anyhow!(e))?
-        })
+    /// Returns the blob archiver url from CLI or environment variable.
+    /// If neither is set, returns None.
+    pub fn blob_archiver_url(&self) -> Option<String> {
+        self.blob_archiver_url.clone().or_else(|| std::env::var(BLOB_ARCHIVER_URL).ok())
     }
 }

--- a/examples/trusted-sync/src/cli.rs
+++ b/examples/trusted-sync/src/cli.rs
@@ -7,6 +7,7 @@ use reqwest::Url;
 const L1_RPC_URL: &str = "L1_RPC_URL";
 const L2_RPC_URL: &str = "L2_RPC_URL";
 const BEACON_URL: &str = "BEACON_URL";
+const BLOB_ARCHIVER_URL: &str = "BLOB_ARCHIVER_URL";
 const METRICS_URL: &str = "METRICS_URL";
 const DEFAULT_METRICS_SERVER_ADDR: &str = "0.0.0.0";
 const DEFAULT_METRICS_SERVER_PORT: u16 = 9000;
@@ -28,6 +29,9 @@ pub struct Cli {
     /// The Beacon URL
     #[clap(long, short)]
     pub beacon_url: Option<String>,
+    /// The Blob Archiver URL
+    #[clap(long, short = 'B')]
+    pub blob_archiver_url: Option<String>,
     /// The l2 block to start from.
     #[clap(long, short, help = "Starting l2 block, defaults to chain genesis if none specified")]
     pub start_l2_block: Option<u64>,
@@ -103,6 +107,14 @@ impl Cli {
             s
         } else {
             std::env::var(BEACON_URL).map_err(|e| anyhow!(e))?
+        })
+    }
+
+    pub fn blob_archiver_url(&self) -> Result<String> {
+        Ok(if let Some(s) = self.blob_archiver_url.clone() {
+            s
+        } else {
+            std::env::var(BLOB_ARCHIVER_URL).map_err(|e| anyhow!(e))?
         })
     }
 }

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -39,7 +39,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     let l1_rpc_url = cli.l1_rpc_url()?;
     let l2_rpc_url = cli.l2_rpc_url()?;
     let beacon_url = cli.beacon_url()?;
-    let blob_archiver_url = cli.blob_archiver_url()?;
+    let blob_archiver_url = cli.blob_archiver_url().ok();
 
     // Query for the L2 Chain ID
     let mut l2_provider =
@@ -72,10 +72,14 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     let mut l2_provider = AlloyL2ChainProvider::new_http(l2_rpc_url.clone(), cfg.clone());
     let attributes =
         StatefulAttributesBuilder::new(cfg.clone(), l2_provider.clone(), l1_provider.clone());
-    let blob_provider = OnlineBlobProviderBuilder::new()
-        .with_primary_beacon_client_url(beacon_url)
-        .with_fallback_beacon_client_url(blob_archiver_url)
-        .build();
+    let blob_provider = if let Some(blob_archiver_url) = blob_archiver_url {
+        OnlineBlobProviderBuilder::new()
+            .with_primary_beacon_client_url(beacon_url)
+            .with_fallback_beacon_client_url(blob_archiver_url)
+            .build()
+    } else {
+        OnlineBlobProviderBuilder::new().with_primary_beacon_client_url(beacon_url).build()
+    };
     let dap = EthereumDataSource::new(l1_provider.clone(), blob_provider, &cfg);
     let mut cursor = l2_provider
         .l2_block_info_by_number(start)

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -72,13 +72,11 @@ async fn sync(cli: cli::Cli) -> Result<()> {
     let mut l2_provider = AlloyL2ChainProvider::new_http(l2_rpc_url.clone(), cfg.clone());
     let attributes =
         StatefulAttributesBuilder::new(cfg.clone(), l2_provider.clone(), l1_provider.clone());
-    let beacon_client = OnlineBeaconClient::new_http(beacon_url);
-    let blob_provider =
-        OnlineBlobProvider::<_, SimpleSlotDerivation>::new(beacon_client, None, None);
-    let blob_archiver = OnlineBeaconClient::new_http(blob_archiver_url);
-    let blob_provider_with_fallback =
-        OnlineBlobProviderWithFallback::new(blob_provider, blob_archiver);
-    let dap = EthereumDataSource::new(l1_provider.clone(), blob_provider_with_fallback, &cfg);
+    let blob_provider = OnlineBlobProviderBuilder::new()
+        .with_primary_beacon_client_url(beacon_url)
+        .with_fallback_beacon_client_url(blob_archiver_url)
+        .build();
+    let dap = EthereumDataSource::new(l1_provider.clone(), blob_provider, &cfg);
     let mut cursor = l2_provider
         .l2_block_info_by_number(start)
         .await


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added a fallback online blob provider in the form of `OnlineBlobProviderWithFallback`.
It will first try to fetch blobs from the primary provider, and proceed with the fallback one if the primary fails.

I added the `BlobSidecarProvider` trait because blob archive APIs aren't required to implement all functions contained in `BeaconClient` (as is the case for https://github.com/base-org/blob-archiver). Furthermore, `genesis_time` and `slot_interval` are taken from the primary provider which is already an online beacon client.

Would something like a `BlobArchiver` struct implementation be useful? 
I'm not sure if that should be left to the caller or to the library.

**Tests**

Added unit tests to make sure that blob fetching is completed even without any sidecar loaded in the primary.

**Additional context**

I need some pointers on error handling and metrics, as I'm not sure of the standard used across the codebase.

**Metadata**

- Fixes #316
