### PR TITLE
fix(examples): Invalid Payload Retries With Backoff

### DIFF
--- a/examples/trusted-sync/src/cli.rs
+++ b/examples/trusted-sync/src/cli.rs
@@ -54,6 +54,13 @@ pub struct Cli {
         help = "Parameterized threshold amount of blocks to drift from before fast-forwarding or walking back"
     )]
     pub drift_threshold: u64,
+    /// Number of failed payload validation retries before recording an invalid payload attributes.
+    #[clap(
+        long,
+        default_value_t = 3,
+        help = "Number of failed payload validation retries before recording an invalid payload attributes"
+    )]
+    pub invalid_payload_retries: u64,
 }
 
 impl Cli {

--- a/examples/trusted-sync/src/metrics.rs
+++ b/examples/trusted-sync/src/metrics.rs
@@ -72,6 +72,10 @@ lazy_static! {
         let opts = opts!("trusted_sync_pipeline_steps", "Number of pipeline steps");
         register_gauge_vec!(opts, &["status"]).expect("Failed to register pipeline steps metric")
     };
+
+    /// Tracks the number of retries for invalid payloads.
+    pub static ref RETRIES: IntCounter =
+        register_int_counter!("trusted_sync_validation_retries", "Invalid Payload Retries").expect("Failed to register retries metric");
 }
 
 /// Starts the metrics server.


### PR DESCRIPTION
**Description**

Since validation can produce an invalid payload attributes to compare to the derived payload attributes (eg when calling `debug_getRawTransaction`, empty tx bytes are returned when they are in fact _not_ empty), we want to retry payload validation a few times before actually recording the **derived** payload attributes as invalid.

There have been multiple instances where this has thrown an alert, without the derived payload attributes being invalid, but instead the validation payload attributes were constructed incorrectly.

Also adds a `trusted_sync_validation_retries` metric that tracks the total number of retries.