### PR TITLE
feat(client): Generic DerivationDriver over any BlobProvider

### DIFF
--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -24,12 +24,13 @@ use kona_primitives::{BlockInfo, L2AttributesWithParent, L2BlockInfo};
 use tracing::{info, warn};
 
 /// An oracle-backed derivation pipeline.
-pub type OraclePipeline<O, B> =
-    DerivationPipeline<OracleAttributesQueue<OracleDataProvider<O, B>, O>, OracleL2ChainProvider<O>>;
+pub type OraclePipeline<O, B> = DerivationPipeline<
+    OracleAttributesQueue<OracleDataProvider<O, B>, O>,
+    OracleL2ChainProvider<O>,
+>;
 
 /// An oracle-backed Ethereum data source.
-pub type OracleDataProvider<O, B> =
-    EthereumDataSource<OracleL1ChainProvider<O>, B>;
+pub type OracleDataProvider<O, B> = EthereumDataSource<OracleL1ChainProvider<O>, B>;
 
 /// An oracle-backed payload attributes builder for the `AttributesQueue` stage of the derivation
 /// pipeline.
@@ -58,7 +59,7 @@ pub type OracleAttributesQueue<DAP, O> = AttributesQueue<
 pub struct DerivationDriver<O, B>
 where
     O: CommsClient + Send + Sync + Debug,
-    B: BlobProvider + Send + Sync + Debug + Clone
+    B: BlobProvider + Send + Sync + Debug + Clone,
 {
     /// The current L2 safe head.
     l2_safe_head: L2BlockInfo,
@@ -71,7 +72,7 @@ where
 impl<O, B> DerivationDriver<O, B>
 where
     O: CommsClient + Send + Sync + Debug,
-    B: BlobProvider + Clone + Send + Sync + Debug
+    B: BlobProvider + Send + Sync + Debug + Clone,
 {
     /// Returns the current L2 safe head [L2BlockInfo].
     pub fn l2_safe_head(&self) -> &L2BlockInfo {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR makes `DerivationDriver` generic over the `BlobProvider` used by extending `OracleDataProvider` with a generic type parameter that replaces the previous `OracleBlobProvider` parameterization. This allows `DerivationDriver` to be instantiated with custom structs that implement the required `BlobProvider` trait.

**Tests**

The existing tests for the ecotone and fjord blocks pass. No tests were added, and no behavior was changed.
