### PR TITLE
fix(kona-host): set explicit types

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -162,22 +162,18 @@ where
                     anyhow::bail!("Invalid hint data length: {}", hint_data.len());
                 }
 
+                let index_data_bytes: [u8; 8] = hint_data[32..40]
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
+                let timestamp_data_bytes: [u8; 8] = hint_data[40..48]
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
                 let hash: B256 = hint_data[0..32]
                     .as_ref()
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to B256: {e}"))?;
-                let index = u64::from_be_bytes(
-                    hint_data[32..40]
-                        .as_ref()
-                        .try_into()
-                        .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?,
-                );
-                let timestamp = u64::from_be_bytes(
-                    hint_data[40..48]
-                        .as_ref()
-                        .try_into()
-                        .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?,
-                );
+                let index = u64::from_be_bytes(index_data_bytes);
+                let timestamp = u64::from_be_bytes(timestamp_data_bytes);
 
                 let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
                 let indexed_hash = IndexedBlobHash { index: index as usize, hash };

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -162,15 +162,15 @@ where
                     anyhow::bail!("Invalid hint data length: {}", hint_data.len());
                 }
 
+                let hash_data_bytes: [u8; 32] = hint_data[0..32]
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to convert bytes to B256: {e}"))?;
                 let index_data_bytes: [u8; 8] = hint_data[32..40]
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
                 let timestamp_data_bytes: [u8; 8] = hint_data[40..48]
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
-                let hash_data_bytes: [u8; 32] = hint_data[0..32]
-                    .try_into()
-                    .map_err(|e| anyhow!("Failed to convert bytes to B256: {e}"))?;
                 let hash: B256 = hash_data_bytes.into();
                 let index = u64::from_be_bytes(index_data_bytes);
                 let timestamp = u64::from_be_bytes(timestamp_data_bytes);

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -171,6 +171,7 @@ where
                 let timestamp_data_bytes: [u8; 8] = hint_data[40..48]
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
+
                 let hash: B256 = hash_data_bytes.into();
                 let index = u64::from_be_bytes(index_data_bytes);
                 let timestamp = u64::from_be_bytes(timestamp_data_bytes);

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -168,10 +168,10 @@ where
                 let timestamp_data_bytes: [u8; 8] = hint_data[40..48]
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to u64: {e}"))?;
-                let hash: B256 = hint_data[0..32]
-                    .as_ref()
+                let hash_data_bytes: [u8; 32] = hint_data[0..32]
                     .try_into()
                     .map_err(|e| anyhow!("Failed to convert bytes to B256: {e}"))?;
+                let hash: B256 = hash_data_bytes.into();
                 let index = u64::from_be_bytes(index_data_bytes);
                 let timestamp = u64::from_be_bytes(timestamp_data_bytes);
 


### PR DESCRIPTION
When importing `kona-host` into different repositories, the Rust compiler isn't smart enough to infer the types from `hint_data[32..40].as_ref().try_into()`.

I've explicitly set the types, which ensures the Rust compiler no longer complains.

This leads to errors such as this:

```bash
error[E0282]: type annotations needed
   --> /Users/ratankaliani/.cargo/git/checkouts/kona-e1a00085bb036f5b/e069eb4/bin/host/src/fetcher/mod.rs:166:22
    |
166 |                     .as_ref()
    |                      ^^^^^^
167 |                     .try_into()
    |                      -------- type must be known at this point
    |
help: try using a fully qualified path to specify the expected types
    |
165 |                 let hash: B256 = <[u8] as AsRef<T>>::as_ref(&hint_data[0..32])
    |                                  ++++++++++++++++++++++++++++                ~

error[E0282]: type annotations needed
   --> /Users/ratankaliani/.cargo/git/checkouts/kona-e1a00085bb036f5b/e069eb4/bin/host/src/fetcher/mod.rs:171:26
    |
171 |                         .as_ref()
    |                          ^^^^^^
172 |                         .try_into()
    |                          -------- type must be known at this point
    |
help: try using a fully qualified path to specify the expected types
    |
170 |                     <[u8] as AsRef<T>>::as_ref(&hint_data[32..40])
    |                     ++++++++++++++++++++++++++++                 ~

error[E0282]: type annotations needed
   --> /Users/ratankaliani/.cargo/git/checkouts/kona-e1a00085bb036f5b/e069eb4/bin/host/src/fetcher/mod.rs:177:26
    |
177 |                         .as_ref()
    |                          ^^^^^^
178 |                         .try_into()
    |                          -------- type must be known at this point
    |
help: try using a fully qualified path to specify the expected types
    |
176 |                     <[u8] as AsRef<T>>::as_ref(&hint_data[40..48])
```

