### PR TITLE
chore(derive): Remove PreviousStage Trait

### DIFF
--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -3,7 +3,7 @@
 /// Re-export trait arguments.
 pub use crate::traits::{
     ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes, OriginAdvancer,
-    OriginProvider, Pipeline, PreviousStage, ResetProvider, ResettableStage, StepResult,
+    OriginProvider, Pipeline, ResetProvider, ResettableStage, StepResult,
 };
 
 /// Re-export stage types that are needed as inputs.

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -1,7 +1,7 @@
 //! Contains the logic for the `AttributesQueue` stage.
 
 use crate::{
-    traits::{NextAttributes, OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{NextAttributes, OriginAdvancer, OriginProvider, ResettableStage},
     types::{
         BlockInfo, L2AttributesWithParent, L2BlockInfo, L2PayloadAttributes, ResetError,
         RollupConfig, SingleBatch, StageError, StageResult, SystemConfig,
@@ -45,7 +45,7 @@ pub trait AttributesProvider {
 #[derive(Debug)]
 pub struct AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     AB: AttributesBuilder + Debug,
 {
     /// The rollup config.
@@ -62,7 +62,7 @@ where
 
 impl<P, AB> AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     AB: AttributesBuilder + Debug,
 {
     /// Create a new [AttributesQueue] stage.
@@ -153,20 +153,10 @@ where
     }
 }
 
-impl<P, AB> PreviousStage for AttributesQueue<P, AB>
-where
-    P: AttributesProvider + PreviousStage + Send + Debug,
-    AB: AttributesBuilder + Send + Debug,
-{
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(&self.prev))
-    }
-}
-
 #[async_trait]
 impl<P, AB> OriginAdvancer for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Debug + Send,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug + Send,
     AB: AttributesBuilder + Debug + Send,
 {
     async fn advance_origin(&mut self) -> StageResult<()> {
@@ -177,7 +167,7 @@ where
 #[async_trait]
 impl<P, AB> NextAttributes for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Debug + Send,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug + Send,
     AB: AttributesBuilder + Debug + Send,
 {
     async fn next_attributes(
@@ -190,7 +180,7 @@ where
 
 impl<P, AB> OriginProvider for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     AB: AttributesBuilder + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -201,7 +191,7 @@ where
 #[async_trait]
 impl<P, AB> ResettableStage for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + PreviousStage + Send + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
     AB: AttributesBuilder + Send + Debug,
 {
     async fn reset(

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::attributes_queue::AttributesProvider,
-    traits::{L2ChainProvider, OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{L2ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
     types::{
         Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, RollupConfig,
         SingleBatch, StageError, StageResult, SystemConfig,
@@ -43,7 +43,7 @@ pub trait BatchQueueProvider {
 #[derive(Debug)]
 pub struct BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// The rollup config.
@@ -75,7 +75,7 @@ where
 
 impl<P, BF> BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// Creates a new [BatchQueue] stage.
@@ -248,7 +248,7 @@ where
 #[async_trait]
 impl<P, BF> OriginAdvancer for BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Send + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     async fn advance_origin(&mut self) -> StageResult<()> {
@@ -259,7 +259,7 @@ where
 #[async_trait]
 impl<P, BF> AttributesProvider for BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Send + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     /// Returns the next valid batch upon the given safe head.
@@ -417,7 +417,7 @@ where
 
 impl<P, BF> OriginProvider for BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug,
     BF: L2ChainProvider + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -425,20 +425,10 @@ where
     }
 }
 
-impl<P, BF> PreviousStage for BatchQueue<P, BF>
-where
-    P: BatchQueueProvider + PreviousStage + Send + Debug,
-    BF: L2ChainProvider + Send + Debug,
-{
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(&self.prev))
-    }
-}
-
 #[async_trait]
 impl<P, BF> ResettableStage for BatchQueue<P, BF>
 where
-    P: BatchQueueProvider + PreviousStage + Send + Debug,
+    P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     async fn reset(&mut self, base: BlockInfo, system_config: &SystemConfig) -> StageResult<()> {

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::L1RetrievalProvider,
-    traits::{ChainProvider, OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
     types::{BlockInfo, RollupConfig, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, sync::Arc};
@@ -115,12 +115,6 @@ impl<F: ChainProvider + Send> OriginAdvancer for L1Traversal<F> {
 impl<F: ChainProvider> OriginProvider for L1Traversal<F> {
     fn origin(&self) -> Option<BlockInfo> {
         self.block
-    }
-}
-
-impl<F: ChainProvider + Send> PreviousStage for L1Traversal<F> {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        None
     }
 }
 

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
     types::{
         BlockID, BlockInfo, BuilderError, L2BlockInfo, L2PayloadAttributes, SingleBatch,
         StageError, StageResult, SystemConfig,
@@ -60,12 +60,6 @@ impl OriginAdvancer for MockAttributesProvider {
 impl ResettableStage for MockAttributesProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
         Ok(())
-    }
-}
-
-impl PreviousStage for MockAttributesProvider {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(self))
     }
 }
 

--- a/crates/derive/src/stages/test_utils/batch_queue.rs
+++ b/crates/derive/src/stages/test_utils/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::batch_queue::BatchQueueProvider,
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
     types::{Batch, BlockInfo, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -48,11 +48,5 @@ impl OriginAdvancer for MockBatchQueueProvider {
 impl ResettableStage for MockBatchQueueProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
         Ok(())
-    }
-}
-
-impl PreviousStage for MockBatchQueueProvider {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(self))
     }
 }

--- a/crates/derive/src/stages/test_utils/channel_bank.rs
+++ b/crates/derive/src/stages/test_utils/channel_bank.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::ChannelBankProvider,
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
     types::{BlockInfo, Frame, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -48,11 +48,5 @@ impl ChannelBankProvider for MockChannelBankProvider {
 impl ResettableStage for MockChannelBankProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
         Ok(())
-    }
-}
-
-impl PreviousStage for MockChannelBankProvider {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(self))
     }
 }

--- a/crates/derive/src/stages/test_utils/channel_reader.rs
+++ b/crates/derive/src/stages/test_utils/channel_reader.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::ChannelReaderProvider,
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
     types::{BlockInfo, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -49,11 +49,5 @@ impl ChannelReaderProvider for MockChannelReaderProvider {
 impl ResettableStage for MockChannelReaderProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
         Ok(())
-    }
-}
-
-impl PreviousStage for MockChannelReaderProvider {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(self))
     }
 }

--- a/crates/derive/src/stages/test_utils/frame_queue.rs
+++ b/crates/derive/src/stages/test_utils/frame_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     stages::FrameQueueProvider,
-    traits::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage},
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
     types::{BlockInfo, StageError, StageResult, SystemConfig},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -49,11 +49,5 @@ impl FrameQueueProvider for MockFrameQueueProvider {
 impl ResettableStage for MockFrameQueueProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
         Ok(())
-    }
-}
-
-impl PreviousStage for MockFrameQueueProvider {
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>> {
-        Some(Box::new(self))
     }
 }

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -17,7 +17,7 @@ mod providers;
 pub use providers::{ChainProvider, L2ChainProvider};
 
 mod stages;
-pub use stages::{OriginAdvancer, OriginProvider, PreviousStage, ResettableStage};
+pub use stages::{OriginAdvancer, OriginProvider, ResettableStage};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/derive/src/traits/stages.rs
+++ b/crates/derive/src/traits/stages.rs
@@ -24,9 +24,3 @@ pub trait OriginAdvancer {
     /// This method is the equivalent of the reference implementation `advance_l1_block`.
     async fn advance_origin(&mut self) -> StageResult<()>;
 }
-
-/// Provides a method for accessing a previous stage.
-pub trait PreviousStage: ResettableStage + OriginAdvancer + OriginProvider {
-    /// Returns the previous stage.
-    fn previous(&self) -> Option<Box<&dyn PreviousStage>>;
-}


### PR DESCRIPTION
**Description**

Removes the `PreviousStage` trait which is a relic from the reference derivation pipeline implementation where resetting stages needed to occur sequentially and the node driver needs to "walk back" the stages, resetting each one individually.

**Metadata**

Fixes #406