### PR TITLE
chore(client): Isolate FPVM-specific constructs

### DIFF
--- a/bin/client/src/fault/caching_oracle.rs
+++ b/bin/client/src/fault/caching_oracle.rs
@@ -3,7 +3,7 @@
 //!
 //! [OracleReader]: kona_preimage::OracleReader
 
-use crate::{HINT_WRITER, ORACLE_READER};
+use super::{HINT_WRITER, ORACLE_READER};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -17,7 +17,7 @@ use spin::Mutex;
 ///
 /// [OracleReader]: kona_preimage::OracleReader
 #[derive(Debug, Clone)]
-pub struct CachingOracle {
+pub(crate) struct CachingOracle {
     /// The spin-locked cache that stores the responses from the oracle.
     cache: Arc<Mutex<LruCache<PreimageKey, Vec<u8>>>>,
 }
@@ -27,7 +27,7 @@ impl CachingOracle {
     /// responses in the cache.
     ///
     /// [OracleReader]: kona_preimage::OracleReader
-    pub fn new(cache_size: usize) -> Self {
+    pub(crate) fn new(cache_size: usize) -> Self {
         Self {
             cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(cache_size).expect("N must be greater than 0"),

--- a/bin/client/src/fault/mod.rs
+++ b/bin/client/src/fault/mod.rs
@@ -1,10 +1,13 @@
-//! Contains the host <-> client communication utilities.
+//! Contains FPVM-specific constructs for the `kona-client` program.
 
 use kona_common::FileDescriptor;
 use kona_preimage::{HintWriter, OracleReader, PipeHandle};
 
 mod caching_oracle;
-pub use caching_oracle::CachingOracle;
+pub(crate) use caching_oracle::CachingOracle;
+
+mod precompiles;
+pub(crate) use precompiles::FPVMPrecompileOverride;
 
 /// The global preimage oracle reader pipe.
 static ORACLE_READER_PIPE: PipeHandle =
@@ -15,7 +18,7 @@ static HINT_WRITER_PIPE: PipeHandle =
     PipeHandle::new(FileDescriptor::HintRead, FileDescriptor::HintWrite);
 
 /// The global preimage oracle reader.
-pub static ORACLE_READER: OracleReader = OracleReader::new(ORACLE_READER_PIPE);
+pub(crate) static ORACLE_READER: OracleReader = OracleReader::new(ORACLE_READER_PIPE);
 
 /// The global hint writer.
-pub static HINT_WRITER: HintWriter = HintWriter::new(HINT_WRITER_PIPE);
+pub(crate) static HINT_WRITER: HintWriter = HintWriter::new(HINT_WRITER_PIPE);

--- a/bin/client/src/fault/precompiles/bn128_pair.rs
+++ b/bin/client/src/fault/precompiles/bn128_pair.rs
@@ -1,36 +1,41 @@
-//! Contains the accelerated version of the KZG point evaluation precompile.
+//! Contains the accelerated version of the `ecPairing` precompile.
 
+use crate::fault::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use anyhow::ensure;
+use kona_client::HintType;
 use kona_preimage::{HintWriterClient, PreimageKey, PreimageKeyType, PreimageOracleClient};
 use revm::{
-    precompile::{u64_to_address, Error as PrecompileError, PrecompileWithAddress},
+    precompile::{
+        bn128::pair::{ISTANBUL_PAIR_BASE, ISTANBUL_PAIR_PER_POINT},
+        u64_to_address, Error as PrecompileError, PrecompileWithAddress,
+    },
     primitives::{Precompile, PrecompileOutput, PrecompileResult},
 };
 
-use crate::{HintType, HINT_WRITER, ORACLE_READER};
+const ECPAIRING_ADDRESS: Address = u64_to_address(8);
+const PAIR_ELEMENT_LEN: usize = 64 + 128;
 
-const POINT_EVAL_ADDRESS: Address = u64_to_address(0x0A);
+pub(crate) const FPVM_ECPAIRING: PrecompileWithAddress =
+    PrecompileWithAddress(ECPAIRING_ADDRESS, Precompile::Standard(fpvm_ecpairing));
 
-pub(crate) const FPVM_KZG_POINT_EVAL: PrecompileWithAddress =
-    PrecompileWithAddress(POINT_EVAL_ADDRESS, Precompile::Standard(fpvm_kzg_point_eval));
+/// Performs an FPVM-accelerated `ecpairing` precompile call.
+fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    let gas_used =
+        (input.len() / PAIR_ELEMENT_LEN) as u64 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
 
-/// Performs an FPVM-accelerated KZG point evaluation precompile call.
-fn fpvm_kzg_point_eval(input: &Bytes, gas_limit: u64) -> PrecompileResult {
-    const GAS_COST: u64 = 50_000;
-
-    if gas_limit < GAS_COST {
+    if gas_used > gas_limit {
         return Err(PrecompileError::OutOfGas.into());
     }
 
-    if input.len() != 192 {
-        return Err(PrecompileError::BlobInvalidInputLength.into());
+    if input.len() % PAIR_ELEMENT_LEN != 0 {
+        return Err(PrecompileError::Bn128PairLength.into());
     }
 
     let result_data = kona_common::block_on(async move {
         // Write the hint for the ecrecover precompile run.
-        let hint_data = &[POINT_EVAL_ADDRESS.as_ref(), input.as_ref()];
+        let hint_data = &[ECPAIRING_ADDRESS.as_ref(), input.as_ref()];
         HINT_WRITER.write(&HintType::L1Precompile.encode_with(hint_data)).await?;
 
         // Construct the key hash for the ecrecover precompile run.
@@ -52,5 +57,5 @@ fn fpvm_kzg_point_eval(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     })
     .map_err(|e| PrecompileError::Other(e.to_string()))?;
 
-    Ok(PrecompileOutput::new(GAS_COST, result_data.into()))
+    Ok(PrecompileOutput::new(gas_used, result_data.into()))
 }

--- a/bin/client/src/fault/precompiles/ecrecover.rs
+++ b/bin/client/src/fault/precompiles/ecrecover.rs
@@ -1,41 +1,32 @@
-//! Contains the accelerated version of the `ecPairing` precompile.
+//! Contains the accelerated version of the `ecrecover` precompile.
 
+use crate::fault::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use anyhow::ensure;
+use kona_client::HintType;
 use kona_preimage::{HintWriterClient, PreimageKey, PreimageKeyType, PreimageOracleClient};
 use revm::{
-    precompile::{
-        bn128::pair::{ISTANBUL_PAIR_BASE, ISTANBUL_PAIR_PER_POINT},
-        u64_to_address, Error as PrecompileError, PrecompileWithAddress,
-    },
+    precompile::{u64_to_address, Error as PrecompileError, PrecompileWithAddress},
     primitives::{Precompile, PrecompileOutput, PrecompileResult},
 };
 
-use crate::{HintType, HINT_WRITER, ORACLE_READER};
+const ECRECOVER_ADDRESS: Address = u64_to_address(1);
 
-const ECPAIRING_ADDRESS: Address = u64_to_address(8);
-const PAIR_ELEMENT_LEN: usize = 64 + 128;
+pub(crate) const FPVM_ECRECOVER: PrecompileWithAddress =
+    PrecompileWithAddress(ECRECOVER_ADDRESS, Precompile::Standard(fpvm_ecrecover));
 
-pub(crate) const FPVM_ECPAIRING: PrecompileWithAddress =
-    PrecompileWithAddress(ECPAIRING_ADDRESS, Precompile::Standard(fpvm_ecpairing));
+/// Performs an FPVM-accelerated `ecrecover` precompile call.
+fn fpvm_ecrecover(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    const ECRECOVER_BASE: u64 = 3_000;
 
-/// Performs an FPVM-accelerated `ecpairing` precompile call.
-fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
-    let gas_used =
-        (input.len() / PAIR_ELEMENT_LEN) as u64 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
-
-    if gas_used > gas_limit {
+    if ECRECOVER_BASE > gas_limit {
         return Err(PrecompileError::OutOfGas.into());
-    }
-
-    if input.len() % PAIR_ELEMENT_LEN != 0 {
-        return Err(PrecompileError::Bn128PairLength.into());
     }
 
     let result_data = kona_common::block_on(async move {
         // Write the hint for the ecrecover precompile run.
-        let hint_data = &[ECPAIRING_ADDRESS.as_ref(), input.as_ref()];
+        let hint_data = &[ECRECOVER_ADDRESS.as_ref(), input.as_ref()];
         HINT_WRITER.write(&HintType::L1Precompile.encode_with(hint_data)).await?;
 
         // Construct the key hash for the ecrecover precompile run.
@@ -57,5 +48,5 @@ fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     })
     .map_err(|e| PrecompileError::Other(e.to_string()))?;
 
-    Ok(PrecompileOutput::new(gas_used, result_data.into()))
+    Ok(PrecompileOutput::new(ECRECOVER_BASE, result_data.into()))
 }

--- a/bin/client/src/fault/precompiles/kzg_point_eval.rs
+++ b/bin/client/src/fault/precompiles/kzg_point_eval.rs
@@ -1,32 +1,36 @@
-//! Contains the accelerated version of the `ecrecover` precompile.
+//! Contains the accelerated version of the KZG point evaluation precompile.
 
+use crate::fault::{HINT_WRITER, ORACLE_READER};
 use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes};
 use anyhow::ensure;
+use kona_client::HintType;
 use kona_preimage::{HintWriterClient, PreimageKey, PreimageKeyType, PreimageOracleClient};
 use revm::{
     precompile::{u64_to_address, Error as PrecompileError, PrecompileWithAddress},
     primitives::{Precompile, PrecompileOutput, PrecompileResult},
 };
 
-use crate::{HintType, HINT_WRITER, ORACLE_READER};
+const POINT_EVAL_ADDRESS: Address = u64_to_address(0x0A);
 
-const ECRECOVER_ADDRESS: Address = u64_to_address(1);
+pub(crate) const FPVM_KZG_POINT_EVAL: PrecompileWithAddress =
+    PrecompileWithAddress(POINT_EVAL_ADDRESS, Precompile::Standard(fpvm_kzg_point_eval));
 
-pub(crate) const FPVM_ECRECOVER: PrecompileWithAddress =
-    PrecompileWithAddress(ECRECOVER_ADDRESS, Precompile::Standard(fpvm_ecrecover));
+/// Performs an FPVM-accelerated KZG point evaluation precompile call.
+fn fpvm_kzg_point_eval(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    const GAS_COST: u64 = 50_000;
 
-/// Performs an FPVM-accelerated `ecrecover` precompile call.
-fn fpvm_ecrecover(input: &Bytes, gas_limit: u64) -> PrecompileResult {
-    const ECRECOVER_BASE: u64 = 3_000;
-
-    if ECRECOVER_BASE > gas_limit {
+    if gas_limit < GAS_COST {
         return Err(PrecompileError::OutOfGas.into());
+    }
+
+    if input.len() != 192 {
+        return Err(PrecompileError::BlobInvalidInputLength.into());
     }
 
     let result_data = kona_common::block_on(async move {
         // Write the hint for the ecrecover precompile run.
-        let hint_data = &[ECRECOVER_ADDRESS.as_ref(), input.as_ref()];
+        let hint_data = &[POINT_EVAL_ADDRESS.as_ref(), input.as_ref()];
         HINT_WRITER.write(&HintType::L1Precompile.encode_with(hint_data)).await?;
 
         // Construct the key hash for the ecrecover precompile run.
@@ -48,5 +52,5 @@ fn fpvm_ecrecover(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     })
     .map_err(|e| PrecompileError::Other(e.to_string()))?;
 
-    Ok(PrecompileOutput::new(ECRECOVER_BASE, result_data.into()))
+    Ok(PrecompileOutput::new(GAS_COST, result_data.into()))
 }

--- a/bin/client/src/fault/precompiles/mod.rs
+++ b/bin/client/src/fault/precompiles/mod.rs
@@ -14,7 +14,7 @@ mod kzg_point_eval;
 
 /// The [PrecompileOverride] implementation for the FPVM-accelerated precompiles.
 #[derive(Debug)]
-pub struct FPVMPrecompileOverride<F, H>
+pub(crate) struct FPVMPrecompileOverride<F, H>
 where
     F: TrieDBFetcher,
     H: TrieDBHinter,

--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -5,18 +5,21 @@
 #![no_std]
 #![cfg_attr(any(target_arch = "mips", target_arch = "riscv64"), no_main)]
 
+extern crate alloc;
+
 use alloc::sync::Arc;
 use alloy_consensus::Header;
 use kona_client::{
     l1::{DerivationDriver, OracleBlobProvider, OracleL1ChainProvider},
-    l2::{FPVMPrecompileOverride, OracleL2ChainProvider},
-    BootInfo, CachingOracle,
+    l2::OracleL2ChainProvider,
+    BootInfo,
 };
 use kona_common_proc::client_entry;
 use kona_executor::StatelessL2BlockExecutor;
 use kona_primitives::L2AttributesWithParent;
 
-extern crate alloc;
+pub(crate) mod fault;
+use fault::{CachingOracle, FPVMPrecompileOverride};
 
 /// The size of the LRU cache in the oracle.
 const ORACLE_LRU_SIZE: usize = 1024;

--- a/bin/client/src/l2/mod.rs
+++ b/bin/client/src/l2/mod.rs
@@ -2,6 +2,3 @@
 
 mod chain_provider;
 pub use chain_provider::OracleL2ChainProvider;
-
-mod precompiles;
-pub use precompiles::FPVMPrecompileOverride;

--- a/bin/client/src/lib.rs
+++ b/bin/client/src/lib.rs
@@ -10,14 +10,8 @@ pub mod l1;
 
 pub mod l2;
 
-pub mod hint;
+mod hint;
 pub use hint::HintType;
 
-mod comms;
-pub use comms::{CachingOracle, HINT_WRITER, ORACLE_READER};
-
-mod boot;
-pub use boot::{
-    BootInfo, L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY,
-    L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY,
-};
+pub mod boot;
+pub use boot::BootInfo;

--- a/bin/host/src/kv/local.rs
+++ b/bin/host/src/kv/local.rs
@@ -3,7 +3,7 @@
 use super::KeyValueStore;
 use crate::cli::HostCli;
 use alloy_primitives::B256;
-use kona_client::{
+use kona_client::boot::{
     L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY,
     L2_ROLLUP_CONFIG_KEY,
 };


### PR DESCRIPTION
## Overview

Isolates the FPVM-specific constructs in the `kona-client` library, only exporting items that are re-usable for different backends.
