### PR TITLE
test(derive): Channel timeout

### DIFF
--- a/crates/derive/src/stages/test_utils/channel_bank.rs
+++ b/crates/derive/src/stages/test_utils/channel_bank.rs
@@ -33,6 +33,10 @@ impl OriginProvider for MockChannelBankProvider {
 #[async_trait]
 impl OriginAdvancer for MockChannelBankProvider {
     async fn advance_origin(&mut self) -> StageResult<()> {
+        self.block_info = self.block_info.map(|mut bi| {
+            bi.number += 1;
+            bi
+        });
         Ok(())
     }
 }


### PR DESCRIPTION
## Overview

Adds a test to the channel bank for channel timeout on OP mainnet & Base Mainnet rollup configs.
