### PR TITLE
feat(client+host): Dynamic `RollupConfig` in bootloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,7 @@ dependencies = [
  "reqwest",
  "revm 13.0.0",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -22,6 +22,8 @@ spin.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 revm.workspace = true
+serde = { version = "1.0.208", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.125", default-features = false }
 
 # local
 kona-common = { path = "../../crates/common", version = "0.0.2" }
@@ -34,10 +36,6 @@ kona-executor = { path = "../../crates/executor", version = "0.0.1" }
 
 # external
 tracing-subscriber = { version = "0.3.18", optional = true }
-
-[dev-dependencies]
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.117"
 
 [features]
 tracing-subscriber = ["dep:tracing-subscriber"]

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -35,7 +35,8 @@ reqwest = "0.12"
 tokio = { version = "1.37.0", features = ["full"] }
 futures = "0.3"
 clap = { version = "4.5.4", features = ["derive", "env"] }
-serde = { version = "1.0.198", features = ["derive"] }
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.125"
 tracing-subscriber = "0.3.18"
 command-fds = { version = "0.3", features = ["tokio"] }
 os_pipe = "1.2.1"

--- a/bin/host/src/kv/local.rs
+++ b/bin/host/src/kv/local.rs
@@ -31,7 +31,11 @@ impl KeyValueStore for LocalKeyValueStore {
             L2_CLAIM_KEY => Some(self.cfg.l2_claim.to_vec()),
             L2_CLAIM_BLOCK_NUMBER_KEY => Some(self.cfg.l2_block_number.to_be_bytes().to_vec()),
             L2_CHAIN_ID_KEY => Some(self.cfg.l2_chain_id.to_be_bytes().to_vec()),
-            L2_ROLLUP_CONFIG_KEY => unimplemented!("L2RollupConfig fetching in local store not implemented. Necessary for chain IDs without a known rollup config."),
+            L2_ROLLUP_CONFIG_KEY => {
+                let rollup_config = self.cfg.read_rollup_config().ok()?;
+                let serialized = serde_json::to_vec(&rollup_config).ok()?;
+                Some(serialized)
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
## Overview

> [!WARNING]
> This feature is _not safe_ for production unless additional validation is performed, i.e. committing to the `RollupConfig` that the user must provide in the verifier contract. Do not use dynamic `RollupConfig` loading unless you understand the implications of an underconstrained `RollupConfig` being passed into the program from the host.

Introduces the option to dynamically load the `RollupConfig` through the `BootInfo` in the bootloader phase of the program. This allows for running `kona` on devnets and alternative chains that are not present in the `superchain-registry`.

cc @zobront 
