### PR TITLE
fix(kdn): Updates `kdn` with op-test-vectors Generic Typing

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  derivation-fixtures:
+  derivation:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -23,5 +23,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - uses: taiki-e/install-action@just
       - name: Run kdn
         run: just test-derivation

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -1,0 +1,27 @@
+name: Test Fixtures
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  derivation-fixtures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.PAT_TOKEN }}
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run kdn
+        run: just test-derivation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "foundry-fork-db",
  "futures",
  "include_directory",
+ "kona-derive",
  "op-test-vectors",
  "reqwest",
  "revm-inspectors",
@@ -4040,11 +4041,11 @@ dependencies = [
  "cfg-if",
  "kona-common",
  "kona-common-proc",
- "kona-derive 0.0.2",
+ "kona-derive",
  "kona-executor",
  "kona-mpt",
  "kona-preimage",
- "kona-primitives 0.0.1",
+ "kona-primitives",
  "lru",
  "op-alloy-consensus",
  "revm 13.0.0",
@@ -4097,7 +4098,7 @@ dependencies = [
  "brotli",
  "c-kzg",
  "hashbrown 0.14.5",
- "kona-primitives 0.0.1",
+ "kona-primitives",
  "lazy_static",
  "lru",
  "miniz_oxide 0.7.4",
@@ -4117,41 +4118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kona-derive"
-version = "0.0.2"
-source = "git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92#4e57dd35ea08b31d0baa293c7a12165f28e6cd92"
-dependencies = [
- "alloc-no-stdlib",
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
- "anyhow",
- "async-trait",
- "brotli",
- "c-kzg",
- "hashbrown 0.14.5",
- "kona-primitives 0.0.1 (git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92)",
- "lru",
- "miniz_oxide 0.7.4",
- "op-alloy-consensus",
- "reqwest",
- "revm 10.0.0",
- "serde",
- "serde_json",
- "sha2",
- "spin",
- "tracing",
- "unsigned-varint",
-]
-
-[[package]]
 name = "kona-executor"
 version = "0.0.1"
 dependencies = [
@@ -4161,7 +4127,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "criterion",
- "kona-derive 0.0.2",
+ "kona-derive",
  "kona-mpt",
  "op-alloy-consensus",
  "pprof",
@@ -4191,7 +4157,7 @@ dependencies = [
  "futures",
  "kona-client",
  "kona-common",
- "kona-derive 0.0.2",
+ "kona-derive",
  "kona-mpt",
  "kona-preimage",
  "os_pipe",
@@ -4238,8 +4204,8 @@ dependencies = [
  "alloy-transport-http",
  "anyhow",
  "async-trait",
- "kona-derive 0.0.2",
- "kona-primitives 0.0.1",
+ "kona-derive",
+ "kona-primitives",
  "reqwest",
  "serde",
  "serde_json",
@@ -4277,22 +4243,6 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "superchain-primitives",
-]
-
-[[package]]
-name = "kona-primitives"
-version = "0.0.1"
-source = "git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92#4e57dd35ea08b31d0baa293c7a12165f28e6cd92"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-sol-types",
- "anyhow",
- "op-alloy-consensus",
- "serde",
  "superchain-primitives",
 ]
 
@@ -4803,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "op-test-vectors"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/tests?branch=main#4886f8469252a2de196b5f5546627f6c19f241a0"
+source = "git+https://github.com/ethereum-optimism/tests?branch=main#6f76ea589a831588995c185cad21181f6c7d3e6f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4811,7 +4761,6 @@ dependencies = [
  "anvil-core",
  "color-eyre",
  "hashbrown 0.14.5",
- "kona-derive 0.0.2 (git+https://github.com/ethereum-optimism/kona?rev=4e57dd35ea08b31d0baa293c7a12165f28e6cd92)",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "serde",
@@ -5737,19 +5686,6 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 6.0.0",
- "revm-precompile 8.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm"
 version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
@@ -5796,15 +5732,6 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "6.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "revm-primitives 5.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
@@ -5820,21 +5747,6 @@ source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faa
 dependencies = [
  "revm-primitives 8.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "k256",
- "once_cell",
- "revm-primitives 5.0.0",
- "ripemd",
- "sha2",
- "substrate-bn",
 ]
 
 [[package]]
@@ -5874,26 +5786,6 @@ dependencies = [
  "secp256k1",
  "sha2",
  "substrate-bn",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "5.0.0"
-source = "git+https://github.com/bluealloy/revm?tag=v37#99367b1db2c436359c0155ed8965c19fc5503a1b"
-dependencies = [
- "alloy-primitives",
- "auto_impl",
- "bitflags 2.6.0",
- "bitvec",
- "c-kzg",
- "cfg-if",
- "derive_more",
- "dyn-clone",
- "enumn",
- "hashbrown 0.14.5",
- "hex",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -6886,9 +6778,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -7373,7 +7265,7 @@ dependencies = [
  "alloy-transport",
  "anyhow",
  "clap",
- "kona-derive 0.0.2",
+ "kona-derive",
  "lazy_static",
  "prometheus",
  "reqwest",

--- a/bin/kdn/Cargo.toml
+++ b/bin/kdn/Cargo.toml
@@ -34,3 +34,4 @@ color-eyre = "0.6" # For op-test-vector dependency
 clap = { version = "4", features = ["derive", "env"] }
 op-test-vectors = { git = "https://github.com/ethereum-optimism/tests", branch = "main" }
 include_directory = "0.1.1"
+kona-derive = { path = "../../crates/derive", version = "0.0.2", features = ["online"] }

--- a/bin/kdn/src/blobs.rs
+++ b/bin/kdn/src/blobs.rs
@@ -2,22 +2,19 @@
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use op_test_vectors::{
-    derivation::DerivationFixture,
-    kona_derive::{
-        traits::BlobProvider,
-        types::{Blob, BlobProviderError, BlockInfo, IndexedBlobHash},
-    },
+use kona_derive::{
+    traits::BlobProvider,
+    types::{Blob, BlobProviderError, BlockInfo, IndexedBlobHash},
 };
 
 /// A blob fixture provider.
 #[derive(Debug, Clone)]
 pub struct BlobFixtureProvider {
-    inner: DerivationFixture,
+    inner: crate::LocalDerivationFixture,
 }
 
-impl From<DerivationFixture> for BlobFixtureProvider {
-    fn from(inner: DerivationFixture) -> Self {
+impl From<crate::LocalDerivationFixture> for BlobFixtureProvider {
+    fn from(inner: crate::LocalDerivationFixture) -> Self {
         Self { inner }
     }
 }

--- a/bin/kdn/src/cli.rs
+++ b/bin/kdn/src/cli.rs
@@ -64,7 +64,7 @@ impl Cli {
         }
     }
 
-    /// Get [DerivationFixture]s to run.
+    /// Get [crate::LocalDerivationFixture]s to run.
     pub fn get_fixtures(&self) -> Result<Vec<(String, crate::LocalDerivationFixture)>> {
         // Get available derivation test fixtures
         let available_tests = Self::get_tests()?;

--- a/bin/kdn/src/cli.rs
+++ b/bin/kdn/src/cli.rs
@@ -3,7 +3,6 @@
 use anyhow::{anyhow, Result};
 use clap::{ArgAction, Parser};
 use include_directory::{include_directory, Dir, DirEntry, File};
-use op_test_vectors::derivation::DerivationFixture;
 use tracing::{debug, error, info, trace, warn, Level};
 
 static TEST_FIXTURES: Dir<'_> =
@@ -50,7 +49,7 @@ impl Cli {
     }
 
     /// Executes a given derivation test fixture.
-    pub async fn exec(&self, name: String, fixture: DerivationFixture) -> Result<()> {
+    pub async fn exec(&self, name: String, fixture: crate::LocalDerivationFixture) -> Result<()> {
         info!(target: "exec", "Running test: {}", name);
         let pipeline = crate::pipeline::new_runner_pipeline(fixture.clone()).await?;
         match crate::runner::run(pipeline, fixture).await {
@@ -66,7 +65,7 @@ impl Cli {
     }
 
     /// Get [DerivationFixture]s to run.
-    pub fn get_fixtures(&self) -> Result<Vec<(String, DerivationFixture)>> {
+    pub fn get_fixtures(&self) -> Result<Vec<(String, crate::LocalDerivationFixture)>> {
         // Get available derivation test fixtures
         let available_tests = Self::get_tests()?;
         trace!("Available tests: {:?}", available_tests);
@@ -82,7 +81,7 @@ impl Cli {
                 debug!("Parsing test fixture: {}", path);
                 Ok((
                     path.to_string(),
-                    serde_json::from_str::<DerivationFixture>(fixture_str)
+                    serde_json::from_str::<crate::LocalDerivationFixture>(fixture_str)
                         .map_err(|e| anyhow!(e))?,
                 ))
             })

--- a/bin/kdn/src/lib.rs
+++ b/bin/kdn/src/lib.rs
@@ -3,6 +3,17 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use kona_derive::types::{Blob, L2BlockInfo, L2PayloadAttributes, RollupConfig, SystemConfig};
+
+/// A local derivation fixture typed with `kona_derive` types.
+pub type LocalDerivationFixture = op_test_vectors::derivation::DerivationFixture<
+    RollupConfig,
+    L2PayloadAttributes,
+    SystemConfig,
+    L2BlockInfo,
+    Blob,
+>;
+
 pub mod cli;
 pub use cli::Cli;
 

--- a/bin/kdn/src/pipeline.rs
+++ b/bin/kdn/src/pipeline.rs
@@ -1,17 +1,14 @@
 //! The pipeline module contains the pipeline logic for the test runner.
 
 use anyhow::{anyhow, Result};
-use op_test_vectors::{
-    derivation::DerivationFixture,
-    kona_derive::{
-        pipeline::{DerivationPipeline, PipelineBuilder},
-        sources::EthereumDataSource,
-        stages::{
-            AttributesQueue, BatchQueue, ChannelBank, ChannelReader, FrameQueue, L1Retrieval,
-            L1Traversal, StatefulAttributesBuilder,
-        },
-        traits::ChainProvider,
+use kona_derive::{
+    pipeline::{DerivationPipeline, PipelineBuilder},
+    sources::EthereumDataSource,
+    stages::{
+        AttributesQueue, BatchQueue, ChannelBank, ChannelReader, FrameQueue, L1Retrieval,
+        L1Traversal, StatefulAttributesBuilder,
     },
+    traits::ChainProvider,
 };
 use std::sync::Arc;
 use tracing::info;
@@ -42,7 +39,7 @@ pub type RunnerAttributesQueue<DAP> = AttributesQueue<
 >;
 
 /// Creates a new [DerivationPipeline] given the [DerivationFixture].
-pub async fn new_runner_pipeline(fixture: DerivationFixture) -> Result<RunnerPipeline> {
+pub async fn new_runner_pipeline(fixture: crate::LocalDerivationFixture) -> Result<RunnerPipeline> {
     let mut l1_provider = FixtureL1Provider::from(fixture.clone());
     let l2_provider = FixtureL2Provider::from(fixture.clone());
     let blob_provider = BlobFixtureProvider::from(fixture.clone());

--- a/bin/kdn/src/pipeline.rs
+++ b/bin/kdn/src/pipeline.rs
@@ -38,7 +38,7 @@ pub type RunnerAttributesQueue<DAP> = AttributesQueue<
     RunnerAttributesBuilder,
 >;
 
-/// Creates a new [DerivationPipeline] given the [DerivationFixture].
+/// Creates a new [DerivationPipeline] given the [crate::LocalDerivationFixture].
 pub async fn new_runner_pipeline(fixture: crate::LocalDerivationFixture) -> Result<RunnerPipeline> {
     let mut l1_provider = FixtureL1Provider::from(fixture.clone());
     let l2_provider = FixtureL2Provider::from(fixture.clone());

--- a/bin/kdn/src/providers.rs
+++ b/bin/kdn/src/providers.rs
@@ -5,14 +5,11 @@ use alloy_eips::eip2718::Decodable2718;
 use alloy_primitives::B256;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use op_test_vectors::{
-    derivation::DerivationFixture,
-    kona_derive::{
-        traits::{ChainProvider, L2ChainProvider},
-        types::{
-            BlockInfo, L2BlockInfo, L2ExecutionPayload, L2ExecutionPayloadEnvelope, RollupConfig,
-            SystemConfig,
-        },
+use kona_derive::{
+    traits::{ChainProvider, L2ChainProvider},
+    types::{
+        BlockInfo, L2BlockInfo, L2ExecutionPayload, L2ExecutionPayloadEnvelope, RollupConfig,
+        SystemConfig,
     },
 };
 use std::sync::Arc;
@@ -20,11 +17,11 @@ use std::sync::Arc;
 /// An L1Provider using the fixture data from the derivation test fixture.
 #[derive(Debug, Clone)]
 pub struct FixtureL1Provider {
-    inner: DerivationFixture,
+    inner: crate::LocalDerivationFixture,
 }
 
-impl From<DerivationFixture> for FixtureL1Provider {
-    fn from(inner: DerivationFixture) -> Self {
+impl From<crate::LocalDerivationFixture> for FixtureL1Provider {
+    fn from(inner: crate::LocalDerivationFixture) -> Self {
         Self { inner }
     }
 }
@@ -87,11 +84,11 @@ impl ChainProvider for FixtureL1Provider {
 /// An L2Provider using the fixture data from the derivation test fixture.
 #[derive(Debug, Clone)]
 pub struct FixtureL2Provider {
-    inner: DerivationFixture,
+    inner: crate::LocalDerivationFixture,
 }
 
-impl From<DerivationFixture> for FixtureL2Provider {
-    fn from(inner: DerivationFixture) -> Self {
+impl From<crate::LocalDerivationFixture> for FixtureL2Provider {
+    fn from(inner: crate::LocalDerivationFixture) -> Self {
         Self { inner }
     }
 }

--- a/bin/kdn/src/runner.rs
+++ b/bin/kdn/src/runner.rs
@@ -3,13 +3,10 @@
 //! The runner that executes the pipeline and validates the output given the test fixtures.
 
 use anyhow::{anyhow, Result};
-use op_test_vectors::{
-    derivation::DerivationFixture,
-    kona_derive::{
-        pipeline::StepResult,
-        traits::{L2ChainProvider, Pipeline},
-        types::StageError,
-    },
+use kona_derive::{
+    pipeline::StepResult,
+    traits::{L2ChainProvider, Pipeline},
+    types::StageError,
 };
 use tracing::{debug, error, info, trace, warn};
 
@@ -18,7 +15,10 @@ use crate::{pipeline::RunnerPipeline, providers::FixtureL2Provider};
 const LOG_TARGET: &str = "runner";
 
 /// Runs the pipeline.
-pub async fn run(mut pipeline: RunnerPipeline, fixture: DerivationFixture) -> Result<()> {
+pub async fn run(
+    mut pipeline: RunnerPipeline,
+    fixture: crate::LocalDerivationFixture,
+) -> Result<()> {
     let mut cursor = *fixture
         .l2_block_infos
         .get(&fixture.l2_cursor_start)

--- a/justfile
+++ b/justfile
@@ -23,6 +23,10 @@ test *args='':
 test-online:
   cargo nextest run --workspace --all --features online
 
+# Run derivation test fixtures against `kona-derive`
+test-derivation:
+  cargo run --bin kdn -- --all 
+
 # Lint the workspace for all available targets
 lint: lint-native lint-cannon lint-asterisc lint-docs
 


### PR DESCRIPTION
**Description**

Updates `kdn` to use the generic `DerivationFixture` with local `kona-derive` types.

Sets up a github action to run derivation tests on pr into trunk.

**Metadata**

Closes #442