### PR TITLE
feat: serde Serialization/Deserialization to BootInfo struct

### DIFF
--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "1.0.125", default-features = false }
 kona-common = { path = "../../crates/common", version = "0.0.2" }
 kona-common-proc = { path = "../../crates/common-proc", version = "0.0.2" }
 kona-preimage = { path = "../../crates/preimage", version = "0.0.2" }
-kona-primitives = { path = "../../crates/primitives", version = "0.0.1" }
+kona-primitives = { path = "../../crates/primitives", version = "0.0.1", features = ["serde"] }
 kona-mpt = { path = "../../crates/mpt", version = "0.0.2" }
 kona-derive = { path = "../../crates/derive", default-features = false, version = "0.0.2" }
 kona-executor = { path = "../../crates/executor", version = "0.0.1" }

--- a/bin/client/src/boot.rs
+++ b/bin/client/src/boot.rs
@@ -3,6 +3,7 @@
 
 use alloy_primitives::{B256, U256};
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use kona_preimage::{PreimageKey, PreimageOracleClient};
 use kona_primitives::RollupConfig;
 use tracing::warn;
@@ -36,7 +37,7 @@ pub const L2_ROLLUP_CONFIG_KEY: U256 = U256::from_be_slice(&[6]);
 /// **User submitted inputs:**
 /// - `l2_claim`: The L2 output root claim.
 /// - `l2_claim_block`: The L2 claim block number.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BootInfo {
     /// The L1 head hash containing the safe L2 chain data that may reproduce the L2 head hash.
     pub l1_head: B256,


### PR DESCRIPTION
**Description**

Since we're passing the rollup config, we'll be able to use the BootInfo struct directly throughout our program (instead of the custom struct we'd previously defined, which didn't include the rollup config).

This requires serialization / deserialization.

Note that I'd usually put this behind a feature flag, but the `client` program already imports serde with the `derive` feature active, so didn't think it was necessary. Let me know if you'd prefer that I do.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

N/A
