### PR TITLE
fix(derive): Remove FPVM Tests in README

### DIFF
--- a/crates/derive/README.md
+++ b/crates/derive/README.md
@@ -1,7 +1,6 @@
 # `kona-derive`
 
   <a href="https://github.com/ethereum-optimism/kona/actions/workflows/rust_ci.yaml"><img src="https://github.com/ethereum-optimism/kona/actions/workflows/rust_ci.yaml/badge.svg?label=ci" alt="CI"></a>
-  <a href="https://github.com/ethereum-optimism/kona/actions/workflows/fpvm_tests.yaml"><img src="https://github.com/ethereum-optimism/kona/actions/workflows/fpvm_tests.yaml/badge.svg?label=FPVM Tests" alt="FPVM Tests"></a>
     <a href="https://crates.io/crates/kona-derive"><img src="https://img.shields.io/crates/v/kona-derive.svg?label=kona-derive&labelColor=2a2f35" alt="Kona Derive"></a>
   <img src="https://img.shields.io/badge/License-MIT-green.svg?label=license&labelColor=2a2f35" alt="License">
 


### PR DESCRIPTION
**Description**

Removes legacy broken fpvm link in `kona-derive` README.