### PR TITLE
feat(client): Export `CachingOracle`

### DIFF
--- a/bin/client/src/fault/mod.rs
+++ b/bin/client/src/fault/mod.rs
@@ -3,9 +3,6 @@
 use kona_common::FileDescriptor;
 use kona_preimage::{HintWriter, OracleReader, PipeHandle};
 
-mod caching_oracle;
-pub(crate) use caching_oracle::CachingOracle;
-
 mod precompiles;
 pub(crate) use precompiles::FPVMPrecompileOverride;
 

--- a/bin/client/src/lib.rs
+++ b/bin/client/src/lib.rs
@@ -15,3 +15,6 @@ pub use hint::HintType;
 
 pub mod boot;
 pub use boot::BootInfo;
+
+mod caching_oracle;
+pub use caching_oracle::CachingOracle;


### PR DESCRIPTION
## Overview

Exports the `CachingOracle` without exporting the underlying pipes.
Expansions of kona, i.e. `op-succinct`, still use this construct.
