### PR TITLE
fix(workspace): Use published `revm` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,7 +5684,8 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "13.0.0"
-source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2f635bbbf4002b1b5c0219f841ec1a317723883ed7662c0d138617539a6087"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -5725,7 +5726,8 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ad04c7d87dc3421a5ccca76e56dbd0b29a358c03bb41fe9e80976e9d3f397d"
 dependencies = [
  "revm-primitives 8.0.0",
  "serde",
@@ -5754,7 +5756,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526a4ba5ec400e7bbe71affbc10fe2e67c1cd1fb782bab988873d09a102e271"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -5796,7 +5799,8 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm#1ad860469755e3cf71383f45d71c3faaf61d3029"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4093d98a26601f0a793871c5bc7928410592f76b1f03fc89fde77180c554643c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ lru = "0.12.3"
 async-trait = "0.1.80"
 
 # Ethereum
-alloy-primitives = { version = "0.7.6", default-features = false }
+alloy-primitives = { version = "0.7.7", default-features = false }
 alloy-rlp = { version = "0.3.5", default-features = false }
 alloy-consensus = { version = "0.2", default-features = false }
 op-alloy-consensus = { version = "0.1.4", default-features = false }
 alloy-eips = { version = "0.2", default-features = false }
-revm = { git = "https://github.com/bluealloy/revm", version = "13.0", default-features = false }
+revm = { version = "13.0", default-features = false }
 
 [profile.dev]
 opt-level = 1

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -20,7 +20,7 @@ revm = { workspace = true, features = ["optimism"] }
 
 # local
 kona-mpt = { path = "../mpt", version = "0.0.2" }
-kona-primitives = { path = "../primitives", version = "0.0.1", default-feature = false }
+kona-primitives = { path = "../primitives", version = "0.0.1", default-features = false }
 
 [dev-dependencies]
 alloy-rlp.workspace = true

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -5,9 +5,9 @@ use alloc::vec::Vec;
 use alloy_consensus::{Header, TxEnvelope};
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::B256;
-
 use alloy_rlp::{RlpDecodable, RlpEncodable};
 use op_alloy_consensus::OpTxEnvelope;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Overview

Switches to use the published `revm` version rather than a git pin, so that we can use `kona-mpt` + `reth-evm-optimism` in `opt8n`.

Also unblocks our releases, as we can't release w/ git deps.