### PR TITLE
chore(derive): Remove udeps

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,7 +25,7 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo llvm-cov
-        run: cargo llvm-cov nextest --locked --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --locked --workspace --lcov --output-path lcov.info --features test-utils
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
       - name: Upload to codecov.io

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -23,7 +23,7 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: cargo test
-        run: cargo nextest run --release --workspace --all --locked
+        run: cargo nextest run --release --workspace --all --all-features --locked
   cargo-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -75,7 +75,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: build benches
-        run: cargo bench --no-run --workspace --all
+        run: cargo bench --no-run --workspace --all --features test-utils
       - name: chown target
         run: |
           sudo chown -R $(id -u):$(id -g) ./target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,9 +949,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -961,7 +958,6 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde",
  "tap",
  "wyz",
 ]
@@ -973,19 +969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1570,7 +1553,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -2252,20 +2234,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "brotli",
- "c-kzg",
  "hashbrown 0.14.5",
  "kona-primitives",
  "lazy_static",
  "lru",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
  "op-alloy-consensus",
  "prometheus",
  "proptest",
  "reqwest",
- "revm",
  "serde",
  "serde_json",
- "sha2",
  "spin",
  "tokio",
  "tracing",
@@ -2385,21 +2364,6 @@ dependencies = [
  "spin",
  "superchain-primitives",
  "tracing",
-]
-
-[[package]]
-name = "kzg-rs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9920cd4460ce3cbca19c62f3bb9a9611562478a4dc9d2c556f4a7d049c5b6b"
-dependencies = [
- "bls12_381",
- "glob",
- "hex",
- "once_cell",
- "serde",
- "serde_derive",
- "serde_yaml",
 ]
 
 [[package]]
@@ -2833,15 +2797,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
-]
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
 ]
 
 [[package]]
@@ -3457,7 +3412,6 @@ dependencies = [
  "enumn",
  "hashbrown 0.14.5",
  "hex",
- "kzg-rs",
  "once_cell",
  "serde",
 ]
@@ -3854,19 +3808,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4633,12 +4574,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -18,11 +18,9 @@ op-alloy-consensus = { workspace = true, features = ["k256"] }
 
 # Other Workspace Dependencies
 lru.workspace = true
-spin.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
-revm = { workspace = true, optional = true }
 
 # Local
 kona-primitives = { path = "../primitives", version = "0.0.1", default-features = false }
@@ -30,7 +28,7 @@ kona-primitives = { path = "../primitives", version = "0.0.1", default-features 
 # External
 hashbrown = "0.14.5"
 unsigned-varint = "0.8.0"
-miniz_oxide = "0.7.3"
+miniz_oxide = "0.8.0"
 brotli = { version = "6.0.0", default-features = false }
 alloc-no-stdlib = "2.0.4"
 
@@ -38,11 +36,8 @@ alloc-no-stdlib = "2.0.4"
 serde = { version = "1.0.203", default-features = false, features = ["derive"], optional = true }
 
 # `online` feature dependencies
-c-kzg = { version = "1.0.2", default-features = false, optional = true }
-sha2 = { version = "0.10.8", default-features = false, optional = true }
 alloy-transport = { version = "0.2", default-features = false, optional = true }
 alloy-provider = { version = "0.2", default-features = false, optional = true }
-alloy-transport-http = { version = "0.2", optional = true } 
 reqwest = { version = "0.12.4", default-features = false, optional = true }
 
 # `metrics` feature dependencies
@@ -50,8 +45,10 @@ lazy_static = { version = "1.5.0", optional = true }
 prometheus = { version = "0.13.4", features = ["process"], optional = true }
 
 # `test-utils` feature dependencies
-alloy-node-bindings = { version = "0.2", default-features = false, optional = true }
+spin = { workspace = true, optional = true }
 tracing-subscriber = { version = "0.3.18", optional = true }
+alloy-node-bindings = { version = "0.2", default-features = false, optional = true }
+alloy-transport-http = { version = "0.2", optional = true } 
 alloy-rpc-client = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -59,7 +56,6 @@ tokio = { version = "1.38", features = ["full"] }
 proptest = "1.4.0"
 tracing-subscriber = "0.3.18"
 alloy-node-bindings = { version = "0.2", default-features = false }
-alloy-rpc-client = { version = "0.2", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 
 [features]
@@ -73,20 +69,18 @@ serde = [
 ]
 metrics = ["dep:prometheus", "dep:lazy_static"]
 online = [
-  "dep:revm",
-  "dep:c-kzg",
-  "dep:sha2",
   "dep:alloy-provider",
   "dep:alloy-transport",
-  "dep:alloy-transport-http",
   "dep:reqwest",
   "alloy-provider/reqwest",
-  "alloy-rpc-client/reqwest",
-  "alloy-transport-http/reqwest",
   "alloy-consensus/serde",
-  "c-kzg/serde",
-  "revm/serde",
-  "revm/c-kzg",
   "kona-primitives/online",
 ]
-test-utils = ["dep:alloy-node-bindings", "dep:tracing-subscriber", "dep:alloy-rpc-client"]
+test-utils = [
+  "dep:spin",
+  "dep:alloy-transport-http",
+  "dep:alloy-node-bindings",
+  "dep:tracing-subscriber",
+  "dep:alloy-rpc-client",
+  "alloy-transport-http/reqwest"
+]

--- a/justfile
+++ b/justfile
@@ -13,15 +13,11 @@ default:
   @just --list
 
 # Run all tests
-tests: test test-online test-docs
+tests: test test-docs
 
 # Test for the native target with all features
 test *args='':
   cargo nextest run --workspace --all --all-features $@
-
-# Run online tests
-test-online:
-  cargo nextest run --workspace --all --features online
 
 # Lint the workspace for all available targets
 lint: lint-native lint-cannon lint-asterisc lint-docs


### PR DESCRIPTION
## Overview

Removes unused dependencies from `kona-derive` and reorganizes the `test-utils` deps such that they are not included in the default dist.
